### PR TITLE
fix(server): drop restrictive rootDir so tsconfig accepts tests/

### DIFF
--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
     "lib": ["ES2022", "DOM"],
     "types": ["node", "jest"]
   },


### PR DESCRIPTION
Server typecheck fail in CI — `scaffold.test.ts` is in `tests/` but `rootDir` was set to `./src`. Removing `rootDir` lets TS infer it from the include array.

## Test plan
- [x] `pnpm typecheck` -> 6/6 packages green
- [x] `pnpm test` -> 3/3 packages green