### PR TITLE
chore(ops): structured logging, env validation, Dockerfile, README runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,118 @@ pnpm install
 ./start              # opens iTerm2 tabs for all 3 services (once implemented)
 ```
 
+## Server runtime configuration
+
+The signaling server validates its environment at boot via a Zod schema. Missing or invalid values fail fast with a single human-readable error.
+
+| Variable | Required | Default | Notes |
+|---|---|---|---|
+| `NODE_ENV` | no | `development` | One of `development`, `test`, `production`. Toggles JSON vs pretty logs. |
+| `PORT` | no | `3010` | Integer 1–65535. |
+| `CORS_ORIGIN` | no | `*` | Origin allowed by Socket.IO. Set to your viewer/camera URLs in production. |
+| `LOG_LEVEL` | no | `info` | One of `fatal`, `error`, `warn`, `info`, `debug`, `trace`, `silent`. |
+| `TURN_URL` | optional | — | Required only when using a TURN relay. Must be set together with `TURN_USER` and `TURN_PASS`. |
+| `TURN_USER` | optional | — | TURN username. |
+| `TURN_PASS` | optional | — | TURN credential. |
+
+A copy-ready `.env.example` lives next to the server (`apps/server/.env.example` — add one if you customize defaults).
+
+## Deploy
+
+The viewer and camera apps are static bundles (Expo Web export and Vite build) and can be uploaded to any static host (Vercel, Netlify, Cloudflare Pages). The signaling server is a long-running Node process — the walkthrough below uses Render's free tier.
+
+### Render free tier (signaling server)
+
+1. Push the `develop` branch to GitHub if you haven't yet.
+2. In Render, **New +** → **Web Service** → connect the GitHub repo.
+3. Configure:
+   - **Runtime**: Docker
+   - **Dockerfile path**: `apps/server/Dockerfile`
+   - **Docker build context**: repository root (`.`)
+   - **Branch**: `main` (only release tags should land here)
+   - **Auto-deploy**: off for the MVP — deploy manually after a `develop → main` merge.
+4. Add the environment variables from the table above. At minimum set `CORS_ORIGIN` to your viewer's deployed origin.
+5. **Health check path**: `/health`.
+6. Create the service. First build pulls workspace deps, compiles TypeScript, and prunes to production-only deps.
+7. Note the public URL Render assigns (e.g. `https://sentinel-server.onrender.com`); paste it into the viewer and camera builds as `VITE_SIGNALING_URL` / `EXPO_PUBLIC_SIGNALING_URL`.
+
+### Local Docker
+
+```bash
+docker compose up --build
+# server now reachable at http://localhost:3010/health
+```
+
+### Static apps (camera + viewer)
+
+```bash
+# Camera (Vite)
+pnpm --filter @sentinel-monitor/camera build
+# upload apps/camera/dist to your static host
+
+# Viewer (Expo web export)
+pnpm --filter @sentinel-monitor/viewer exec expo export --platform web
+# upload apps/viewer/dist (or the directory configured in app.json) to your static host
+```
+
+## Monitoring
+
+The server emits structured JSON logs to stdout via [pino](https://getpino.io/). Each log line carries:
+
+- `time` — ISO timestamp
+- `level` — pino numeric level (`30` info, `40` warn, `50` error)
+- `service` — always `sentinel-server`
+- `event` — domain-event tag (e.g. `socket.connected`, `pairing.code_issued`, `pairing.redeem_failed`, `presence.registered`, `presence.removed`, `signal.dropped`, `boot.listening`, `boot.shutdown`)
+- `correlationId` + `socketId` — bound to a child logger per Socket.IO connection so you can trace a single client end-to-end
+
+What to watch in production:
+
+| Signal | What it tells you |
+|---|---|
+| Spike in `pairing.redeem_failed` (`reason: "NOT_FOUND"`) | Camera and dashboard clocks drifted, or operators are typing wrong codes. |
+| `signal.dropped` events | A peer is going offline mid-handshake. Confirm presence churn. |
+| `presence.registered` count vs `presence.removed` count | Should balance over time. A growing gap means orphan presence — investigate. |
+| `boot.shutdown` outside a planned deploy | Process was killed (OOM, host restart). Check the platform's process logs. |
+| `/health` → non-200 | Liveness check failed. Render will restart automatically. |
+
+On Render: **Logs** tab streams stdout in real time. Use the **Search** box with the JSON `event` value (e.g. `pairing.redeem_failed`) to filter.
+
+## Troubleshooting
+
+**Server fails to boot with `Invalid server environment: ...`**
+The Zod env validator caught a misconfiguration. The error names the offending variable. Fix it in your platform's env config and redeploy. Validation runs before the listener binds, so the process exits with code `1`.
+
+**Camera shows "connected" but dashboard never receives video**
+Check three places, in order:
+1. Server logs around the connection time — search by `correlationId` to follow both peers.
+2. Browser devtools on both peers — look for ICE failures. If the operator is on a restrictive network, you need TURN. Set `TURN_URL`, `TURN_USER`, `TURN_PASS` and redeploy.
+3. `CORS_ORIGIN` matches the actual viewer/camera origins. A wildcard (`*`) works but is not recommended in production.
+
+**`pairing.redeem_failed` with `NOT_FOUND`**
+Pairing codes expire after 5 minutes. Generate a fresh code from the camera and retry. If it still fails, check that the dashboard hits the same server URL the camera registered against.
+
+**High latency / dropped signals**
+Render's free tier sleeps idle services. The first request after sleep takes 30–60s. For real production use, upgrade to a paid plan or move to a host without idle suspension (Fly.io, Railway).
+
+**Logs are unreadable JSON in development**
+Ensure `NODE_ENV` is unset or `development` — the server only enables `pino-pretty` outside production. In Docker the default is `production`; override with `-e NODE_ENV=development` when poking around locally.
+
+**Useful commands**
+
+```bash
+# Tail logs from a running container
+docker compose logs -f server
+
+# One-off health probe
+curl -s http://localhost:3010/health | jq
+
+# Rebuild the image after server source changes
+docker compose build server && docker compose up -d server
+
+# Inspect parsed env on boot — the first JSON line includes the safe view
+docker compose logs server | head -n 5
+```
+
 ## Branching policy
 
 - `main` — locked. Receives only the v1.0.0 release merge.

--- a/apps/server/.dockerignore
+++ b/apps/server/.dockerignore
@@ -1,0 +1,17 @@
+**/node_modules
+**/dist
+**/coverage
+**/.turbo
+**/.next
+**/.expo
+**/.cache
+**/.DS_Store
+**/.git
+**/.github
+**/*.log
+**/.env
+**/.env.*
+!**/.env.example
+**/tests
+**/*.test.ts
+**/*.spec.ts

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,0 +1,67 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage build for the Sentinel Monitor signaling server.
+# Stage 1: install full workspace deps, compile TypeScript.
+# Stage 2: prune to production deps only.
+# Stage 3: minimal runtime image.
+
+ARG NODE_VERSION=20.18.0
+ARG PNPM_VERSION=9.12.0
+
+# ---------- Stage 1: build ----------
+FROM node:${NODE_VERSION}-alpine AS build
+ARG PNPM_VERSION
+WORKDIR /repo
+
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+
+# Copy workspace manifests first for better layer caching.
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json turbo.json tsconfig.base.json ./
+COPY apps/server/package.json apps/server/
+COPY packages/shared-types/package.json packages/shared-types/
+
+RUN pnpm install --frozen-lockfile --filter @sentinel-monitor/server...
+
+# Copy sources for the server and the workspace package it depends on.
+COPY packages/shared-types packages/shared-types
+COPY apps/server apps/server
+
+RUN pnpm --filter @sentinel-monitor/server build
+
+# ---------- Stage 2: prune ----------
+FROM node:${NODE_VERSION}-alpine AS prune
+ARG PNPM_VERSION
+WORKDIR /repo
+
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY apps/server/package.json apps/server/
+COPY packages/shared-types/package.json packages/shared-types/
+COPY packages/shared-types packages/shared-types
+
+RUN pnpm install --frozen-lockfile --prod --filter @sentinel-monitor/server...
+
+# ---------- Stage 3: runtime ----------
+FROM node:${NODE_VERSION}-alpine AS runtime
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    PORT=3010 \
+    LOG_LEVEL=info
+
+# Bring in pruned node_modules from the workspace plus compiled JS.
+COPY --from=prune /repo/node_modules /app/node_modules
+COPY --from=prune /repo/apps/server/node_modules /app/node_modules
+COPY --from=prune /repo/packages /app/packages
+COPY --from=build /repo/apps/server/dist /app/dist
+COPY --from=build /repo/apps/server/package.json /app/package.json
+
+# Run as the non-root user shipped in the node:alpine images.
+USER node
+
+EXPOSE 3010
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget --quiet --spider http://127.0.0.1:${PORT}/health || exit 1
+
+CMD ["node", "dist/main.js"]

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -16,13 +16,16 @@
   "dependencies": {
     "@sentinel-monitor/shared-types": "workspace:*",
     "express": "^4.21.0",
-    "socket.io": "^4.8.0"
+    "pino": "^9.5.0",
+    "socket.io": "^4.8.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/express": "^4.17.0",
     "@types/jest": "^29.5.0",
     "@types/node": "^20.0.0",
     "jest": "^29.7.0",
+    "pino-pretty": "^11.2.2",
     "socket.io-client": "^4.8.0",
     "ts-jest": "^29.2.0",
     "tsx": "^4.19.0",

--- a/apps/server/src/infrastructure/config/env.ts
+++ b/apps/server/src/infrastructure/config/env.ts
@@ -1,0 +1,90 @@
+import { z } from 'zod';
+
+/**
+ * Schema for the runtime environment of the signaling server. Centralizing the
+ * shape lets us fail fast at boot when configuration drifts and gives the rest
+ * of the codebase a typed, validated object to depend on.
+ */
+const envSchema = z.object({
+  NODE_ENV: z
+    .enum(['development', 'test', 'production'])
+    .default('development'),
+  PORT: z
+    .string()
+    .optional()
+    .default('3010')
+    .transform((value, ctx) => {
+      const parsed = Number(value);
+      if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'PORT must be an integer between 1 and 65535',
+        });
+        return z.NEVER;
+      }
+      return parsed;
+    }),
+  CORS_ORIGIN: z.string().min(1).default('*'),
+  LOG_LEVEL: z
+    .enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'])
+    .default('info'),
+  TURN_URL: z.string().url().optional(),
+  TURN_USER: z.string().min(1).optional(),
+  TURN_PASS: z.string().min(1).optional(),
+});
+
+export type IServerEnv = z.infer<typeof envSchema>;
+
+export class EnvValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly issues: readonly z.ZodIssue[],
+  ) {
+    super(message);
+    this.name = 'EnvValidationError';
+  }
+}
+
+/**
+ * Parse and validate the given environment record. Throws EnvValidationError
+ * with a human-readable summary of the failures when validation fails.
+ */
+export function loadEnv(source: NodeJS.ProcessEnv = process.env): IServerEnv {
+  const result = envSchema.safeParse(source);
+  if (!result.success) {
+    const summary = result.error.issues
+      .map((issue) => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
+      .join('; ');
+    throw new EnvValidationError(
+      `Invalid server environment: ${summary}`,
+      result.error.issues,
+    );
+  }
+
+  // TURN credentials must be all-or-nothing.
+  const env = result.data;
+  const turnFields = [env.TURN_URL, env.TURN_USER, env.TURN_PASS];
+  const turnDefined = turnFields.filter((value) => value !== undefined).length;
+  if (turnDefined !== 0 && turnDefined !== 3) {
+    throw new EnvValidationError(
+      'Invalid server environment: TURN_URL, TURN_USER, and TURN_PASS must be set together or not at all',
+      [],
+    );
+  }
+
+  return env;
+}
+
+/**
+ * Public-safe view of the loaded env (omits TURN credentials) so it can be
+ * logged at boot without leaking secrets.
+ */
+export function describeEnv(env: IServerEnv): Record<string, unknown> {
+  return {
+    nodeEnv: env.NODE_ENV,
+    port: env.PORT,
+    corsOrigin: env.CORS_ORIGIN,
+    logLevel: env.LOG_LEVEL,
+    turnConfigured: env.TURN_URL !== undefined,
+  };
+}

--- a/apps/server/src/infrastructure/logging/logger.ts
+++ b/apps/server/src/infrastructure/logging/logger.ts
@@ -1,0 +1,90 @@
+import pino, { type Logger as PinoLogger, type LoggerOptions } from 'pino';
+
+/**
+ * Application-facing logger contract. Use cases and handlers depend on this
+ * interface (DIP) so the concrete pino implementation can be swapped or
+ * stubbed in tests without ripple effects.
+ */
+export interface ILogger {
+  info(payload: Record<string, unknown> | string, message?: string): void;
+  warn(payload: Record<string, unknown> | string, message?: string): void;
+  error(payload: Record<string, unknown> | string, message?: string): void;
+  debug(payload: Record<string, unknown> | string, message?: string): void;
+  child(bindings: Record<string, unknown>): ILogger;
+}
+
+export interface ILoggerOptions {
+  readonly level?: string;
+  readonly pretty?: boolean;
+  readonly base?: Record<string, unknown>;
+  readonly destination?: NodeJS.WritableStream;
+}
+
+class PinoAdapter implements ILogger {
+  constructor(private readonly inner: PinoLogger) {}
+
+  info(payload: Record<string, unknown> | string, message?: string): void {
+    this.write('info', payload, message);
+  }
+
+  warn(payload: Record<string, unknown> | string, message?: string): void {
+    this.write('warn', payload, message);
+  }
+
+  error(payload: Record<string, unknown> | string, message?: string): void {
+    this.write('error', payload, message);
+  }
+
+  debug(payload: Record<string, unknown> | string, message?: string): void {
+    this.write('debug', payload, message);
+  }
+
+  child(bindings: Record<string, unknown>): ILogger {
+    return new PinoAdapter(this.inner.child(bindings));
+  }
+
+  private write(
+    level: 'info' | 'warn' | 'error' | 'debug',
+    payload: Record<string, unknown> | string,
+    message?: string,
+  ): void {
+    if (typeof payload === 'string') {
+      this.inner[level](payload);
+      return;
+    }
+    if (message === undefined) {
+      this.inner[level](payload);
+      return;
+    }
+    this.inner[level](payload, message);
+  }
+}
+
+/**
+ * Create a structured logger. In production, output is single-line JSON for
+ * downstream log shippers. In development, pino-pretty is enabled when
+ * available to give a readable stream.
+ */
+export function createLogger(options: ILoggerOptions = {}): ILogger {
+  const opts: LoggerOptions = {
+    level: options.level ?? 'info',
+    base: options.base ?? { service: 'sentinel-server' },
+    timestamp: pino.stdTimeFunctions.isoTime,
+  };
+
+  if (options.pretty) {
+    try {
+      opts.transport = {
+        target: 'pino-pretty',
+        options: { colorize: true, translateTime: 'SYS:HH:MM:ss.l' },
+      };
+    } catch {
+      // pino-pretty not installed; fall through to JSON output.
+    }
+  }
+
+  const inner = options.destination
+    ? pino(opts, options.destination)
+    : pino(opts);
+  return new PinoAdapter(inner);
+}

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -16,11 +16,34 @@ import { HandleDisconnectUseCase } from './domain/use-cases/handle-disconnect.us
 import { RedeemPairingCodeUseCase } from './domain/use-cases/redeem-pairing-code.use-case';
 import { RegisterPresenceUseCase } from './domain/use-cases/register-presence.use-case';
 import { RouteSignalUseCase } from './domain/use-cases/route-signal.use-case';
+import {
+  describeEnv,
+  EnvValidationError,
+  loadEnv,
+  type IServerEnv,
+} from './infrastructure/config/env';
+import { createLogger } from './infrastructure/logging/logger';
 import { HealthHandler } from './presentation/handlers/health.handler';
 import { SocketHandler } from './presentation/handlers/socket.handler';
 
-const PORT = Number(process.env.PORT ?? 3010);
-const CORS_ORIGIN = process.env.CORS_ORIGIN ?? '*';
+let env: IServerEnv;
+try {
+  env = loadEnv();
+} catch (err) {
+  // Logger not yet built; emit a single bootstrap error and exit.
+  // eslint-disable-next-line no-console
+  console.error(
+    err instanceof EnvValidationError ? err.message : 'Failed to load environment',
+  );
+  process.exit(1);
+}
+
+const logger = createLogger({
+  level: env.LOG_LEVEL,
+  pretty: env.NODE_ENV !== 'production',
+});
+
+logger.info({ event: 'boot.env', config: describeEnv(env) }, 'environment loaded');
 
 // ---- Repositories (data layer) ----
 const presenceRepo = new InMemoryPeerPresenceRepository();
@@ -37,7 +60,7 @@ const handleDisconnect = new HandleDisconnectUseCase(presenceRepo);
 const app = express();
 const httpServer = createServer(app);
 const io = new Server<IClientToServerEvents, IServerToClientEvents>(httpServer, {
-  cors: { origin: CORS_ORIGIN },
+  cors: { origin: env.CORS_ORIGIN },
 });
 
 // ---- Presentation handlers ----
@@ -49,9 +72,20 @@ new SocketHandler({
   routeSignal,
   handleDisconnect,
   presence: presenceRepo,
+  logger,
 }).register(io);
 
-httpServer.listen(PORT, () => {
-  // eslint-disable-next-line no-console
-  console.log(`Sentinel signaling server listening on :${PORT}`);
+httpServer.listen(env.PORT, () => {
+  logger.info(
+    { event: 'boot.listening', port: env.PORT },
+    `Sentinel signaling server listening on :${env.PORT}`,
+  );
 });
+
+const shutdown = (signal: string): void => {
+  logger.info({ event: 'boot.shutdown', signal }, 'shutting down');
+  httpServer.close(() => process.exit(0));
+};
+
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));

--- a/apps/server/src/presentation/handlers/socket.handler.ts
+++ b/apps/server/src/presentation/handlers/socket.handler.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import type { Server, Socket } from 'socket.io';
 import type {
   IClientToServerEvents,
@@ -19,9 +20,18 @@ import type { HandleDisconnectUseCase } from '../../domain/use-cases/handle-disc
 import type { RedeemPairingCodeUseCase } from '../../domain/use-cases/redeem-pairing-code.use-case';
 import type { RegisterPresenceUseCase } from '../../domain/use-cases/register-presence.use-case';
 import type { RouteSignalUseCase } from '../../domain/use-cases/route-signal.use-case';
+import type { ILogger } from '../../infrastructure/logging/logger';
 
 export type TypedServer = Server<IClientToServerEvents, IServerToClientEvents>;
 export type TypedSocket = Socket<IClientToServerEvents, IServerToClientEvents>;
+
+const noopLogger: ILogger = {
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+  debug: () => undefined,
+  child: () => noopLogger,
+};
 
 export interface ISocketHandlerDeps {
   readonly registerPresence: RegisterPresenceUseCase;
@@ -30,30 +40,50 @@ export interface ISocketHandlerDeps {
   readonly routeSignal: RouteSignalUseCase;
   readonly handleDisconnect: HandleDisconnectUseCase;
   readonly presence: IPeerPresenceRepository;
+  readonly logger?: ILogger;
+  readonly correlationIdFactory?: () => string;
 }
 
 /**
  * Bridges the Socket.IO transport with the domain use cases. Holds in-memory
  * subscription sets per socket so dashboards can be notified when the cameras
- * they care about change presence.
+ * they care about change presence. Each socket gets a child logger bound to
+ * a correlation ID so events can be traced across the connection lifetime.
  */
 export class SocketHandler {
   // socketId -> set of peerIds the socket is subscribed to
   private readonly subscriptions = new Map<string, Set<string>>();
+  private readonly logger: ILogger;
+  private readonly newCorrelationId: () => string;
 
-  constructor(private readonly deps: ISocketHandlerDeps) {}
+  constructor(private readonly deps: ISocketHandlerDeps) {
+    this.logger = deps.logger ?? noopLogger;
+    this.newCorrelationId = deps.correlationIdFactory ?? randomUUID;
+  }
 
   register(io: TypedServer): void {
     io.on('connection', (socket) => this.onConnection(io, socket));
   }
 
   private onConnection(io: TypedServer, socket: TypedSocket): void {
+    const correlationId = this.newCorrelationId();
+    const log = this.logger.child({
+      correlationId,
+      socketId: socket.id,
+    });
+
+    log.info({ event: 'socket.connected' }, 'socket connected');
+
     socket.on('register-presence', (data: RegisterPresenceDto) => {
       this.deps.registerPresence.execute({
         peerId: data.peerId,
         role: data.role,
         socketId: socket.id,
       });
+      log.info(
+        { event: 'presence.registered', peerId: data.peerId, role: data.role },
+        'peer registered',
+      );
       this.broadcastPresence(io, { peerId: data.peerId, online: true });
     });
 
@@ -61,6 +91,14 @@ export class SocketHandler {
       'request-pairing-code',
       (data: RequestPairingCodeDto, ack: (response: PairingCodeIssuedDto) => void) => {
         const issued = this.deps.generatePairingCode.execute({ cameraId: data.cameraId });
+        log.info(
+          {
+            event: 'pairing.code_issued',
+            cameraId: data.cameraId,
+            expiresAt: issued.expiresAt,
+          },
+          'pairing code issued',
+        );
         ack(issued);
       },
     );
@@ -76,9 +114,25 @@ export class SocketHandler {
           dashboardId: data.dashboardId,
         });
         if (!result.success) {
+          log.warn(
+            {
+              event: 'pairing.redeem_failed',
+              dashboardId: data.dashboardId,
+              reason: result.error.code,
+            },
+            'pairing redeem failed',
+          );
           ack(result.error);
           return;
         }
+        log.info(
+          {
+            event: 'pairing.redeemed',
+            cameraId: result.data.cameraId,
+            dashboardId: result.data.dashboardId,
+          },
+          'pairing redeemed',
+        );
         ack(result.data);
         const cameraSocketId = this.deps.presence.getSocketId(result.data.cameraId);
         if (cameraSocketId) {
@@ -103,7 +157,17 @@ export class SocketHandler {
 
     socket.on('signal', (data: SignalDto) => {
       const result = this.deps.routeSignal.execute(data);
-      if (!result.routed) return;
+      if (!result.routed) {
+        log.debug(
+          {
+            event: 'signal.dropped',
+            fromPeerId: data.fromPeerId,
+            toPeerId: data.toPeerId,
+          },
+          'signal dropped (offline recipient)',
+        );
+        return;
+      }
       io.to(result.toSocketId).emit('signal', result.payload);
     });
 
@@ -111,8 +175,13 @@ export class SocketHandler {
       this.subscriptions.delete(socket.id);
       const result = this.deps.handleDisconnect.execute({ socketId: socket.id });
       if (result.removed) {
+        log.info(
+          { event: 'presence.removed', peerId: result.peerId },
+          'peer removed on disconnect',
+        );
         this.broadcastPresence(io, { peerId: result.peerId, online: false });
       }
+      log.info({ event: 'socket.disconnected' }, 'socket disconnected');
     });
   }
 

--- a/apps/server/tests/unit/env.test.ts
+++ b/apps/server/tests/unit/env.test.ts
@@ -1,0 +1,97 @@
+import { describeEnv, EnvValidationError, loadEnv } from '../../src/infrastructure/config/env';
+
+describe('loadEnv', () => {
+  it('applies defaults when no env vars are provided', () => {
+    const env = loadEnv({});
+    expect(env.PORT).toBe(3010);
+    expect(env.CORS_ORIGIN).toBe('*');
+    expect(env.NODE_ENV).toBe('development');
+    expect(env.LOG_LEVEL).toBe('info');
+    expect(env.TURN_URL).toBeUndefined();
+  });
+
+  it('parses PORT as a number', () => {
+    const env = loadEnv({ PORT: '4242' });
+    expect(env.PORT).toBe(4242);
+  });
+
+  it('throws EnvValidationError when PORT is not a valid integer', () => {
+    expect(() => loadEnv({ PORT: 'not-a-port' })).toThrow(EnvValidationError);
+  });
+
+  it('throws EnvValidationError when PORT is out of range', () => {
+    expect(() => loadEnv({ PORT: '70000' })).toThrow(EnvValidationError);
+  });
+
+  it('throws EnvValidationError when NODE_ENV is unknown', () => {
+    expect(() => loadEnv({ NODE_ENV: 'staging' })).toThrow(EnvValidationError);
+  });
+
+  it('accepts a valid TURN trio', () => {
+    const env = loadEnv({
+      TURN_URL: 'turns:turn.example.com:5349',
+      TURN_USER: 'alice',
+      TURN_PASS: 'secret',
+    });
+    expect(env.TURN_URL).toBe('turns:turn.example.com:5349');
+    expect(env.TURN_USER).toBe('alice');
+    expect(env.TURN_PASS).toBe('secret');
+  });
+
+  it('throws when TURN credentials are partially provided', () => {
+    expect(() =>
+      loadEnv({
+        TURN_URL: 'turns:turn.example.com:5349',
+        TURN_USER: 'alice',
+      }),
+    ).toThrow(/TURN_URL, TURN_USER, and TURN_PASS/);
+  });
+
+  it('rejects non-URL TURN_URL values', () => {
+    expect(() =>
+      loadEnv({
+        TURN_URL: 'not a url',
+        TURN_USER: 'alice',
+        TURN_PASS: 'secret',
+      }),
+    ).toThrow(EnvValidationError);
+  });
+
+  it('produces a human-readable error message', () => {
+    try {
+      loadEnv({ PORT: 'abc' });
+      fail('expected loadEnv to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(EnvValidationError);
+      expect((err as EnvValidationError).message).toMatch(/PORT/);
+    }
+  });
+});
+
+describe('describeEnv', () => {
+  it('exposes safe fields and signals TURN as configured', () => {
+    const env = loadEnv({
+      PORT: '3010',
+      TURN_URL: 'turns:turn.example.com:5349',
+      TURN_USER: 'alice',
+      TURN_PASS: 'secret',
+    });
+    const description = describeEnv(env);
+    expect(description).toEqual({
+      nodeEnv: 'development',
+      port: 3010,
+      corsOrigin: '*',
+      logLevel: 'info',
+      turnConfigured: true,
+    });
+    // It must not leak credentials.
+    const serialized = JSON.stringify(description);
+    expect(serialized).not.toContain('secret');
+    expect(serialized).not.toContain('alice');
+  });
+
+  it('reports turnConfigured as false when TURN is unset', () => {
+    const env = loadEnv({});
+    expect(describeEnv(env).turnConfigured).toBe(false);
+  });
+});

--- a/apps/server/tests/unit/logger.test.ts
+++ b/apps/server/tests/unit/logger.test.ts
@@ -1,0 +1,88 @@
+import { Writable } from 'stream';
+import { createLogger } from '../../src/infrastructure/logging/logger';
+
+interface ICapturedLine {
+  level: number;
+  msg: string;
+  service?: string;
+  event?: string;
+  correlationId?: string;
+  socketId?: string;
+  peerId?: string;
+  [key: string]: unknown;
+}
+
+function captureStream(): {
+  stream: Writable;
+  lines: () => ICapturedLine[];
+} {
+  const chunks: string[] = [];
+  const stream = new Writable({
+    write(chunk, _encoding, callback): void {
+      chunks.push(chunk.toString());
+      callback();
+    },
+  });
+  return {
+    stream,
+    lines: (): ICapturedLine[] =>
+      chunks
+        .join('')
+        .split('\n')
+        .filter((line) => line.length > 0)
+        .map((line) => JSON.parse(line) as ICapturedLine),
+  };
+}
+
+describe('createLogger', () => {
+  it('emits structured JSON with service base field', () => {
+    const cap = captureStream();
+    const log = createLogger({ destination: cap.stream });
+    log.info({ event: 'test.event' }, 'hello');
+    const [line] = cap.lines();
+    expect(line).toBeDefined();
+    expect(line!.msg).toBe('hello');
+    expect(line!.event).toBe('test.event');
+    expect(line!.service).toBe('sentinel-server');
+    expect(typeof line!.time).toBe('string');
+  });
+
+  it('respects the configured log level', () => {
+    const cap = captureStream();
+    const log = createLogger({ destination: cap.stream, level: 'warn' });
+    log.info({ event: 'noisy' }, 'should not appear');
+    log.warn({ event: 'important' }, 'should appear');
+    const lines = cap.lines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0]!.event).toBe('important');
+  });
+
+  it('child logger inherits bindings (correlation id propagates)', () => {
+    const cap = captureStream();
+    const root = createLogger({ destination: cap.stream });
+    const child = root.child({ correlationId: 'abc-123', socketId: 'sock-1' });
+    child.info({ event: 'connection' }, 'connected');
+    const [line] = cap.lines();
+    expect(line!.correlationId).toBe('abc-123');
+    expect(line!.socketId).toBe('sock-1');
+    expect(line!.event).toBe('connection');
+  });
+
+  it('supports plain string messages', () => {
+    const cap = captureStream();
+    const log = createLogger({ destination: cap.stream });
+    log.error('plain error');
+    const [line] = cap.lines();
+    expect(line!.msg).toBe('plain error');
+    expect(line!.level).toBe(50);
+  });
+
+  it('debug level can be enabled and emits records', () => {
+    const cap = captureStream();
+    const log = createLogger({ destination: cap.stream, level: 'debug' });
+    log.debug({ event: 'trace' }, 'debug msg');
+    const [line] = cap.lines();
+    expect(line!.event).toBe('trace');
+    expect(line!.level).toBe(20);
+  });
+});

--- a/apps/server/tests/unit/socket.handler.logging.test.ts
+++ b/apps/server/tests/unit/socket.handler.logging.test.ts
@@ -1,0 +1,178 @@
+import { createServer, type Server as HttpServer } from 'http';
+import type { AddressInfo } from 'net';
+import { Server } from 'socket.io';
+import { io as createClient, type Socket as ClientSocket } from 'socket.io-client';
+import type {
+  IClientToServerEvents,
+  IServerToClientEvents,
+  PairingCodeIssuedDto,
+} from '@sentinel-monitor/shared-types';
+
+import { InMemoryPairingCodeRepository } from '../../src/data/repositories/in-memory-pairing-code.repository';
+import { InMemoryPeerPresenceRepository } from '../../src/data/repositories/in-memory-peer-presence.repository';
+import { GeneratePairingCodeUseCase } from '../../src/domain/use-cases/generate-pairing-code.use-case';
+import { HandleDisconnectUseCase } from '../../src/domain/use-cases/handle-disconnect.use-case';
+import { RedeemPairingCodeUseCase } from '../../src/domain/use-cases/redeem-pairing-code.use-case';
+import { RegisterPresenceUseCase } from '../../src/domain/use-cases/register-presence.use-case';
+import { RouteSignalUseCase } from '../../src/domain/use-cases/route-signal.use-case';
+import type { ILogger } from '../../src/infrastructure/logging/logger';
+import { SocketHandler } from '../../src/presentation/handlers/socket.handler';
+
+type TypedClient = ClientSocket<IServerToClientEvents, IClientToServerEvents>;
+
+interface ILoggedRecord {
+  level: 'info' | 'warn' | 'error' | 'debug';
+  payload: Record<string, unknown> | string;
+  message?: string;
+  bindings: Record<string, unknown>;
+}
+
+class RecordingLogger implements ILogger {
+  constructor(
+    public readonly records: ILoggedRecord[] = [],
+    private readonly bindings: Record<string, unknown> = {},
+  ) {}
+
+  info(payload: Record<string, unknown> | string, message?: string): void {
+    this.records.push({ level: 'info', payload, message, bindings: this.bindings });
+  }
+  warn(payload: Record<string, unknown> | string, message?: string): void {
+    this.records.push({ level: 'warn', payload, message, bindings: this.bindings });
+  }
+  error(payload: Record<string, unknown> | string, message?: string): void {
+    this.records.push({ level: 'error', payload, message, bindings: this.bindings });
+  }
+  debug(payload: Record<string, unknown> | string, message?: string): void {
+    this.records.push({ level: 'debug', payload, message, bindings: this.bindings });
+  }
+  child(bindings: Record<string, unknown>): ILogger {
+    return new RecordingLogger(this.records, { ...this.bindings, ...bindings });
+  }
+}
+
+interface ITestRig {
+  httpServer: HttpServer;
+  io: Server<IClientToServerEvents, IServerToClientEvents>;
+  port: number;
+  logger: RecordingLogger;
+}
+
+async function setupRig(correlationId = 'corr-fixed'): Promise<ITestRig> {
+  const presence = new InMemoryPeerPresenceRepository();
+  const pairing = new InMemoryPairingCodeRepository();
+  const logger = new RecordingLogger();
+  const handler = new SocketHandler({
+    registerPresence: new RegisterPresenceUseCase(presence),
+    generatePairingCode: new GeneratePairingCodeUseCase(pairing),
+    redeemPairingCode: new RedeemPairingCodeUseCase(pairing),
+    routeSignal: new RouteSignalUseCase(presence),
+    handleDisconnect: new HandleDisconnectUseCase(presence),
+    presence,
+    logger,
+    correlationIdFactory: () => correlationId,
+  });
+
+  const httpServer = createServer();
+  const io = new Server<IClientToServerEvents, IServerToClientEvents>(httpServer);
+  handler.register(io);
+
+  await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', resolve));
+  const port = (httpServer.address() as AddressInfo).port;
+  return { httpServer, io, port, logger };
+}
+
+async function tearDown(rig: ITestRig, clients: TypedClient[]): Promise<void> {
+  for (const c of clients) c.disconnect();
+  await new Promise<void>((resolve) => rig.io.close(() => resolve()));
+  await new Promise<void>((resolve) => rig.httpServer.close(() => resolve()));
+}
+
+function connectClient(port: number): Promise<TypedClient> {
+  const client = createClient(`http://127.0.0.1:${port}`, {
+    transports: ['websocket'],
+    forceNew: true,
+  }) as TypedClient;
+  return new Promise((resolve, reject) => {
+    client.once('connect', () => resolve(client));
+    client.once('connect_error', reject);
+  });
+}
+
+describe('SocketHandler logging', () => {
+  let rig: ITestRig;
+  let clients: TypedClient[];
+
+  beforeEach(async () => {
+    rig = await setupRig();
+    clients = [];
+  });
+
+  afterEach(async () => {
+    await tearDown(rig, clients);
+  });
+
+  it('binds correlationId + socketId to all per-connection logs', async () => {
+    const cam = await connectClient(rig.port);
+    clients.push(cam);
+    cam.emit('register-presence', { peerId: 'cam-1', role: 'camera' });
+    await new Promise((r) => setTimeout(r, 30));
+
+    const connectRecord = rig.logger.records.find(
+      (r) => typeof r.payload === 'object' && r.payload.event === 'socket.connected',
+    );
+    expect(connectRecord).toBeDefined();
+    expect(connectRecord!.bindings.correlationId).toBe('corr-fixed');
+    expect(typeof connectRecord!.bindings.socketId).toBe('string');
+
+    const presenceRecord = rig.logger.records.find(
+      (r) => typeof r.payload === 'object' && r.payload.event === 'presence.registered',
+    );
+    expect(presenceRecord).toBeDefined();
+    expect((presenceRecord!.payload as Record<string, unknown>).peerId).toBe('cam-1');
+    expect((presenceRecord!.payload as Record<string, unknown>).role).toBe('camera');
+    expect(presenceRecord!.bindings.correlationId).toBe('corr-fixed');
+  });
+
+  it('logs pairing.code_issued at info level with cameraId', async () => {
+    const cam = await connectClient(rig.port);
+    clients.push(cam);
+    await new Promise<PairingCodeIssuedDto>((resolve) => {
+      cam.emit('request-pairing-code', { cameraId: 'cam-9' }, resolve);
+    });
+    const issued = rig.logger.records.find(
+      (r) => typeof r.payload === 'object' && r.payload.event === 'pairing.code_issued',
+    );
+    expect(issued).toBeDefined();
+    expect(issued!.level).toBe('info');
+    expect((issued!.payload as Record<string, unknown>).cameraId).toBe('cam-9');
+  });
+
+  it('logs pairing.redeem_failed at warn level when code is unknown', async () => {
+    const dashboard = await connectClient(rig.port);
+    clients.push(dashboard);
+    await new Promise((resolve) => {
+      dashboard.emit(
+        'redeem-pairing-code',
+        { code: 'UNKNOWN', dashboardId: 'dash-1' },
+        resolve,
+      );
+    });
+    const failed = rig.logger.records.find(
+      (r) => typeof r.payload === 'object' && r.payload.event === 'pairing.redeem_failed',
+    );
+    expect(failed).toBeDefined();
+    expect(failed!.level).toBe('warn');
+    expect((failed!.payload as Record<string, unknown>).reason).toBe('NOT_FOUND');
+  });
+
+  it('logs socket.disconnected on disconnect', async () => {
+    const cam = await connectClient(rig.port);
+    cam.disconnect();
+    await new Promise((r) => setTimeout(r, 60));
+    const disc = rig.logger.records.find(
+      (r) => typeof r.payload === 'object' && r.payload.event === 'socket.disconnected',
+    );
+    expect(disc).toBeDefined();
+    expect(disc!.bindings.correlationId).toBe('corr-fixed');
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+# Local infra for the Sentinel Monitor signaling server.
+# Camera and viewer apps are static deploys; you run them with their own dev
+# scripts (Vite / Expo) and point them at the server URL exposed below.
+
+services:
+  server:
+    container_name: sentinel-server
+    build:
+      context: .
+      dockerfile: apps/server/Dockerfile
+    image: sentinel-monitor/server:local
+    restart: unless-stopped
+    ports:
+      - "${SERVER_PORT:-3010}:3010"
+    environment:
+      NODE_ENV: production
+      PORT: 3010
+      CORS_ORIGIN: ${CORS_ORIGIN:-*}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      TURN_URL: ${TURN_URL:-}
+      TURN_USER: ${TURN_USER:-}
+      TURN_PASS: ${TURN_PASS:-}
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--spider", "http://127.0.0.1:3010/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,9 +54,15 @@ importers:
       express:
         specifier: ^4.21.0
         version: 4.22.1
+      pino:
+        specifier: ^9.5.0
+        version: 9.14.0
       socket.io:
         specifier: ^4.8.0
         version: 4.8.3
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
     devDependencies:
       '@types/express':
         specifier: ^4.17.0
@@ -70,6 +76,9 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.19.39)
+      pino-pretty:
+        specifier: ^11.2.2
+        version: 11.3.0
       socket.io-client:
         specifier: ^4.8.0
         version: 4.8.3
@@ -1242,7 +1251,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.22.28':
     resolution: {integrity: sha512-lvt72KNitGuixYD2l3SZmRKVu2G4zJpmg5V7WfUBNpmUU5oODBw/6qmiJ6kSLAlfDozscUk+BBGknBBzxUrwrA==}
@@ -1450,6 +1459,9 @@ packages:
   '@npmcli/fs@3.1.1':
     resolution: {integrity: sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -2084,6 +2096,10 @@ packages:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
 
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
   babel-core@7.0.0-bridge.0:
     resolution: {integrity: sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==}
     peerDependencies:
@@ -2235,6 +2251,9 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -2373,6 +2392,9 @@ packages:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
 
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -2484,6 +2506,9 @@ packages:
   data-urls@3.0.2:
     resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
     engines: {node: '>=12'}
+
+  dateformat@4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -2730,6 +2755,10 @@ packages:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   execa@1.0.0:
     resolution: {integrity: sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==}
     engines: {node: '>=6'}
@@ -2843,6 +2872,9 @@ packages:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
 
+  fast-copy@3.0.2:
+    resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -2855,6 +2887,9 @@ packages:
 
   fast-loops@1.1.4:
     resolution: {integrity: sha512-8dbd3XWoKCTms18ize6JmQF1SFnnfj5s0B7rRry22EofgMu7B6LKHVh+XfFqFGsqnbH54xgeO83PzpKI+ODhlg==}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
@@ -3070,6 +3105,9 @@ packages:
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
+
+  help-me@5.0.0:
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
   hermes-estree@0.23.1:
     resolution: {integrity: sha512-eT5MU3f5aVhTqsfIReZ6n41X5sYn4IdQL0nvz6yO+MMlPxw49aSARHLg/MSehQftyjnrE8X6bYregzSumqc6cg==}
@@ -3428,6 +3466,10 @@ packages:
 
   join-component@1.1.0:
     resolution: {integrity: sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -3893,6 +3935,10 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
     engines: {node: '>= 0.8'}
@@ -4038,6 +4084,20 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
+  pino-pretty@11.3.0:
+    resolution: {integrity: sha512-oXwn7ICywaZPHmu3epHGU2oJX4nPmKvHvB/bwrJHlGcbEWaVcotkpyVHMKLKmiVryWYByNp0jpgAcXpFJDXJzA==}
+    hasBin: true
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@9.14.0:
+    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
+    hasBin: true
+
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -4080,6 +4140,13 @@ packages:
   proc-log@4.2.0:
     resolution: {integrity: sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
 
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
@@ -4139,6 +4206,9 @@ packages:
 
   queue@6.0.2:
     resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -4232,8 +4302,16 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   readline@1.3.0:
     resolution: {integrity: sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg==}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
 
   recast@0.21.5:
     resolution: {integrity: sha512-hjMmLaUXAm1hIuTqOdeYObMslq/q+Xff6QE3Y2P+uoHAg2nmVlLBps2hzh1UJDdMtDTMXOFewK6ky51JQIeECg==}
@@ -4337,6 +4415,10 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -4357,6 +4439,9 @@ packages:
   schema-utils@4.3.3:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
+
+  secure-json-parse@2.7.0:
+    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
 
   selfsigned@2.4.1:
     resolution: {integrity: sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==}
@@ -4490,6 +4575,9 @@ packages:
     resolution: {integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==}
     engines: {node: '>=10.2.0'}
 
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -4511,6 +4599,10 @@ packages:
   split-on-first@1.1.0:
     resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
     engines: {node: '>=6'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -4563,6 +4655,9 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@5.2.0:
     resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
@@ -4666,6 +4761,9 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
@@ -5159,6 +5257,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zustand@5.0.12:
     resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
@@ -6779,6 +6880,8 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  '@pinojs/redact@0.4.0': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -7537,6 +7640,8 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
+  atomic-sleep@1.0.0: {}
+
   babel-core@7.0.0-bridge.0(@babel/core@7.29.0):
     dependencies:
       '@babel/core': 7.29.0
@@ -7752,6 +7857,11 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   bytes@3.1.2: {}
 
   cacache@18.0.4:
@@ -7892,6 +8002,8 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
 
+  colorette@2.0.20: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -8021,6 +8133,8 @@ snapshots:
       abab: 2.0.6
       whatwg-mimetype: 3.0.0
       whatwg-url: 11.0.0
+
+  dateformat@4.6.3: {}
 
   debug@2.6.9:
     dependencies:
@@ -8270,6 +8384,8 @@ snapshots:
 
   event-target-shim@5.0.1: {}
 
+  events@3.3.0: {}
+
   execa@1.0.0:
     dependencies:
       cross-spawn: 6.0.6
@@ -8472,6 +8588,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fast-copy@3.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -8485,6 +8603,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-loops@1.1.4: {}
+
+  fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.1.0: {}
 
@@ -8745,6 +8865,8 @@ snapshots:
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
+
+  help-me@5.0.0: {}
 
   hermes-estree@0.23.1: {}
 
@@ -9275,6 +9397,8 @@ snapshots:
   jimp-compact@0.16.1: {}
 
   join-component@1.1.0: {}
+
+  joycon@3.1.1: {}
 
   js-tokens@10.0.0: {}
 
@@ -9820,6 +9944,8 @@ snapshots:
 
   obug@2.1.1: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   on-finished@2.3.0:
     dependencies:
       ee-first: 1.1.1
@@ -9947,6 +10073,43 @@ snapshots:
 
   pify@4.0.1: {}
 
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-pretty@11.3.0:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 3.0.2
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pump: 3.0.4
+      readable-stream: 4.7.0
+      secure-json-parse: 2.7.0
+      sonic-boom: 4.2.1
+      strip-json-comments: 3.1.1
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@9.14.0:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 3.1.0
+
   pirates@4.0.7: {}
 
   pkg-dir@3.0.0:
@@ -9988,6 +10151,10 @@ snapshots:
       react-is: 18.3.1
 
   proc-log@4.2.0: {}
+
+  process-warning@5.0.0: {}
+
+  process@0.11.10: {}
 
   progress@2.0.3: {}
 
@@ -10052,6 +10219,8 @@ snapshots:
   queue@6.0.2:
     dependencies:
       inherits: 2.0.4
+
+  quick-format-unescaped@4.0.4: {}
 
   range-parser@1.2.1: {}
 
@@ -10202,7 +10371,17 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
   readline@1.3.0: {}
+
+  real-require@0.2.0: {}
 
   recast@0.21.5:
     dependencies:
@@ -10325,6 +10504,8 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  safe-stable-stringify@2.5.0: {}
+
   safer-buffer@2.1.2: {}
 
   sax@1.6.0: {}
@@ -10347,6 +10528,8 @@ snapshots:
       ajv: 8.20.0
       ajv-formats: 2.1.1(ajv@8.20.0)
       ajv-keywords: 5.1.0(ajv@8.20.0)
+
+  secure-json-parse@2.7.0: {}
 
   selfsigned@2.4.1:
     dependencies:
@@ -10509,6 +10692,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.13:
@@ -10526,6 +10713,8 @@ snapshots:
   source-map@0.6.1: {}
 
   split-on-first@1.1.0: {}
+
+  split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
 
@@ -10571,6 +10760,10 @@ snapshots:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   strip-ansi@5.2.0:
     dependencies:
@@ -10677,6 +10870,10 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  thread-stream@3.1.0:
+    dependencies:
+      real-require: 0.2.0
 
   throat@5.0.0: {}
 
@@ -11032,6 +11229,8 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zod@3.25.76: {}
 
   zustand@5.0.12(@types/react@18.3.28)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)):
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Pino-based `ILogger` interface in `apps/server/src/infrastructure/logging/logger.ts` (DIP — handlers depend on the interface, not pino). JSON output by default, pino-pretty in non-production.
- `SocketHandler` now binds a child logger per Socket.IO connection with `correlationId` + `socketId`, and emits structured events (`socket.connected`, `presence.registered`, `pairing.code_issued`, `pairing.redeem_failed`, `pairing.redeemed`, `signal.dropped`, `presence.removed`, `socket.disconnected`).
- Zod env schema in `apps/server/src/infrastructure/config/env.ts` validates `NODE_ENV`, `PORT`, `CORS_ORIGIN`, `LOG_LEVEL`, and the optional TURN trio (all-or-nothing). Bootstrap fails fast with a human-readable message; safe view is logged at boot (TURN credentials redacted).
- Multi-stage `apps/server/Dockerfile` (build → prune → runtime) running as the `node` user with a `/health` HEALTHCHECK, plus `.dockerignore` and a root `docker-compose.yml` exposing the server on `${SERVER_PORT:-3010}`.
- README extended with Server runtime configuration, Deploy (Render free tier walkthrough + local Docker + static apps), Monitoring (log shape, what to watch), and Troubleshooting sections.

## Notes
- Docker daemon was unavailable in this environment; the image build was not executed locally. The Dockerfile follows the same multi-stage pnpm workspace pattern used elsewhere and copies pruned `node_modules` from the prune stage. Verify with `docker compose up --build` before tagging a release.
- No CI workflow changes (out of scope per issue).
- Coverage on new files: `env.ts` 100% stmts / 81% branches; `logger.ts` 81% stmts / 60% branches; `socket.handler.ts` 98% stmts / 100% branches. Overall server stays at ~97%.

## Test plan
- [x] `pnpm typecheck` (workspace) — green
- [x] `pnpm --filter @sentinel-monitor/server test` — 14 suites / 68 tests pass
- [x] `pnpm --filter @sentinel-monitor/server test -- --coverage` — overall ≥ 80%
- [ ] `docker compose up --build` on a host with the Docker daemon running, then `curl http://localhost:3010/health`
- [ ] Manual Render deploy following README walkthrough
- [ ] Verify a missing/invalid `PORT` aborts boot with the Zod error

Closes #10