### PR TITLE
feat(viewer): WebRTC subscriber + presence store + connect flow (web)

### DIFF
--- a/apps/viewer/app/_layout.tsx
+++ b/apps/viewer/app/_layout.tsx
@@ -2,14 +2,23 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect, useState } from 'react';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { initBindingsStore } from '@/presentation/bootstrap';
+import { initRuntime } from '@/presentation/bootstrap';
 
 export default function RootLayout(): JSX.Element | null {
   const [ready, setReady] = useState<boolean>(false);
 
   useEffect(() => {
-    const store = initBindingsStore();
-    void store.getState().hydrate().finally(() => setReady(true));
+    const runtime = initRuntime();
+    void runtime
+      .start()
+      .catch((err) => {
+        // eslint-disable-next-line no-console
+        console.warn('[viewer] start failed', err);
+      })
+      .finally(() => setReady(true));
+    return () => {
+      void runtime.stop();
+    };
   }, []);
 
   if (!ready) return null;

--- a/apps/viewer/app/index.tsx
+++ b/apps/viewer/app/index.tsx
@@ -6,6 +6,8 @@ import { AddCameraModal } from '@/presentation/components/add-camera-modal';
 import { CameraTile } from '@/presentation/components/camera-tile.component';
 import { EmptyState } from '@/presentation/components/empty-state';
 import { useBindingsStore } from '@/presentation/stores/bindings.store';
+import { usePeersStore } from '@/presentation/stores/peers.store';
+import { usePresenceStore } from '@/presentation/stores/presence.store';
 import { radii, semantic, spacing, typography } from '@/presentation/theme';
 
 const layoutUC = new ComputeGridLayoutUseCase();

--- a/apps/viewer/jest.config.js
+++ b/apps/viewer/jest.config.js
@@ -30,6 +30,7 @@ module.exports = {
   collectCoverageFrom: [
     'src/domain/**/*.ts',
     'src/presentation/stores/**/*.ts',
+    'src/infrastructure/signaling/**/*.ts',
   ],
   coverageThreshold: {
     global: {

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -20,6 +20,7 @@
     "@react-native-async-storage/async-storage": "1.23.1",
     "@sentinel-monitor/design-tokens": "workspace:*",
     "@sentinel-monitor/shared-types": "workspace:*",
+    "@sentinel-monitor/webrtc-config": "workspace:^",
     "expo": "~52.0.0",
     "expo-constants": "~17.0.0",
     "expo-linking": "~7.0.0",
@@ -31,11 +32,13 @@
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",
     "react-native-web": "~0.19.13",
+    "socket.io-client": "^4.8.0",
     "zustand": "^5.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.0",
     "@types/jest": "^29.5.0",
+    "@types/node": "^20.0.0",
     "@types/react": "~18.3.12",
     "@types/react-dom": "~18.3.1",
     "babel-preset-expo": "~12.0.0",

--- a/apps/viewer/src/domain/repositories/i-signaling.repository.ts
+++ b/apps/viewer/src/domain/repositories/i-signaling.repository.ts
@@ -1,0 +1,34 @@
+// ============================================================
+// Domain port for the dashboard's signaling channel.
+// Surface: presence registration / queries / subscription, pairing
+// code redemption, and the bidirectional signal pipe.
+// ============================================================
+
+import type {
+  PairingErrorDto,
+  PairingRedeemedDto,
+  PresenceChangeDto,
+  PresenceSnapshotDto,
+  SignalDto,
+} from '@sentinel-monitor/shared-types';
+
+export type RedeemPairingResult =
+  | { readonly success: true; readonly data: PairingRedeemedDto }
+  | { readonly success: false; readonly error: PairingErrorDto };
+
+export interface ISignalingRepository {
+  connect(): Promise<void>;
+  disconnect(): void;
+  isConnected(): boolean;
+
+  registerPresence(peerId: string): void;
+  redeemPairingCode(code: string, dashboardId: string): Promise<RedeemPairingResult>;
+  queryPresence(peerIds: readonly string[]): Promise<PresenceSnapshotDto>;
+  subscribePresence(peerIds: readonly string[]): void;
+
+  sendSignal(signal: SignalDto): void;
+  onSignal(handler: (signal: SignalDto) => void): void;
+  offSignal(handler: (signal: SignalDto) => void): void;
+  onPresenceChange(handler: (change: PresenceChangeDto) => void): void;
+  offPresenceChange(handler: (change: PresenceChangeDto) => void): void;
+}

--- a/apps/viewer/src/domain/repositories/i-webrtc-subscriber.repository.ts
+++ b/apps/viewer/src/domain/repositories/i-webrtc-subscriber.repository.ts
@@ -1,0 +1,32 @@
+// ============================================================
+// Domain port for the WebRTC subscriber. The subscriber initiates
+// the offer to a remote camera, receives back an answer, and
+// surfaces the inbound MediaStream once tracks arrive.
+// ============================================================
+
+import type { SignalPayload } from '@sentinel-monitor/shared-types';
+
+export type SubscriberState =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'disconnected'
+  | 'failed'
+  | 'closed';
+
+export interface IWebRtcSubscriberRepository {
+  /**
+   * Kick off the subscriber-driven WebRTC handshake. Implementations
+   * MUST call signalSink with the offer and any ICE candidates.
+   */
+  connect(cameraId: string): Promise<void>;
+  /** Apply an inbound signal (answer / ICE) routed by the server. */
+  handleIncomingSignal(payload: SignalPayload): Promise<void>;
+  /** Tear down the underlying RTCPeerConnection. */
+  close(): void;
+
+  onTrack(handler: (stream: MediaStream) => void): void;
+  onStateChange(handler: (state: SubscriberState) => void): void;
+
+  getState(): SubscriberState;
+}

--- a/apps/viewer/src/domain/use-cases/add-camera.use-case.ts
+++ b/apps/viewer/src/domain/use-cases/add-camera.use-case.ts
@@ -50,8 +50,9 @@ export class AddCameraUseCase {
       addedAt: this.deps.now(),
     };
 
-    // TODO: PR6 — ConnectToCameraUseCase will open the WebRTC
-    // peer connection here, then this binding becomes "live".
+    // The realtime side (subscribePresence + ConnectToCameraUseCase)
+    // is wired by StartViewerSessionUseCase from the store layer once
+    // the new binding is persisted.
     return CameraBindingEntity.create(props);
   }
 }

--- a/apps/viewer/src/domain/use-cases/connect-to-camera.use-case.ts
+++ b/apps/viewer/src/domain/use-cases/connect-to-camera.use-case.ts
@@ -1,0 +1,82 @@
+// ============================================================
+// ConnectToCamera — orchestrates a single subscriber-driven
+// WebRTC handshake against one remote camera through the
+// shared signaling channel.
+//
+// Lifecycle:
+//   1. Build a fresh subscriber via the injected factory
+//   2. Wire signal in/out (offer + ICE) through the signaling repo
+//   3. On inbound MediaStream → publish to peers store
+//   4. On state change → publish to peers store
+//   5. Return a disposer that closes the peer connection
+// ============================================================
+
+import type {
+  SignalDto,
+  SignalPayload,
+} from '@sentinel-monitor/shared-types';
+import type { ISignalingRepository } from '../repositories/i-signaling.repository';
+import type {
+  IWebRtcSubscriberRepository,
+  SubscriberState,
+} from '../repositories/i-webrtc-subscriber.repository';
+
+export type SubscriberFactory = (
+  cameraId: string,
+  emitSignal: (payload: SignalPayload) => void,
+) => IWebRtcSubscriberRepository;
+
+export interface ConnectToCameraDeps {
+  readonly signaling: ISignalingRepository;
+  readonly subscriberFactory: SubscriberFactory;
+  readonly dashboardId: string;
+  readonly onStream: (cameraId: string, stream: MediaStream) => void;
+  readonly onState: (cameraId: string, state: SubscriberState) => void;
+}
+
+export interface CameraConnection {
+  readonly cameraId: string;
+  readonly subscriber: IWebRtcSubscriberRepository;
+  close(): void;
+}
+
+export class ConnectToCameraUseCase {
+  constructor(private readonly deps: ConnectToCameraDeps) {}
+
+  async execute(cameraId: string): Promise<CameraConnection> {
+    const { signaling, subscriberFactory, dashboardId, onStream, onState } =
+      this.deps;
+
+    const emitSignal = (payload: SignalPayload): void => {
+      signaling.sendSignal({
+        fromPeerId: dashboardId,
+        toPeerId: cameraId,
+        payload,
+      });
+    };
+
+    const subscriber = subscriberFactory(cameraId, emitSignal);
+
+    subscriber.onTrack((stream) => onStream(cameraId, stream));
+    subscriber.onStateChange((state) => onState(cameraId, state));
+
+    const signalHandler = (signal: SignalDto): void => {
+      if (signal.fromPeerId !== cameraId) return;
+      void subscriber.handleIncomingSignal(signal.payload);
+    };
+    signaling.onSignal(signalHandler);
+
+    onState(cameraId, 'connecting');
+    await subscriber.connect(cameraId);
+
+    return {
+      cameraId,
+      subscriber,
+      close: (): void => {
+        signaling.offSignal(signalHandler);
+        subscriber.close();
+        onState(cameraId, 'closed');
+      },
+    };
+  }
+}

--- a/apps/viewer/src/domain/use-cases/start-viewer-session.use-case.ts
+++ b/apps/viewer/src/domain/use-cases/start-viewer-session.use-case.ts
@@ -1,0 +1,115 @@
+// ============================================================
+// StartViewerSession — once the viewer has hydrated its identity
+// and bindings, this orchestrates the realtime side:
+//   1. Connect to the signaling socket
+//   2. Register presence as a 'dashboard'
+//   3. Query + subscribe presence for every bound cameraId
+//   4. Trigger ConnectToCamera for every camera that is online
+//   5. React to presence-change events (online → connect, offline → close)
+//
+// Returns a disposer that closes all open peer connections and
+// unsubscribes presence handlers.
+// ============================================================
+
+import type { PresenceChangeDto } from '@sentinel-monitor/shared-types';
+import type { CameraBindingEntity } from '../entities/camera-binding.entity';
+import type { ISignalingRepository } from '../repositories/i-signaling.repository';
+import type {
+  CameraConnection,
+  ConnectToCameraUseCase,
+} from './connect-to-camera.use-case';
+
+export interface StartViewerSessionDeps {
+  readonly signaling: ISignalingRepository;
+  readonly connectToCamera: ConnectToCameraUseCase;
+  readonly dashboardId: string;
+  readonly onPresenceSnapshot: (online: readonly string[]) => void;
+  readonly onPresenceChange: (cameraId: string, online: boolean) => void;
+}
+
+export interface StartViewerSessionInput {
+  readonly bindings: readonly CameraBindingEntity[];
+}
+
+export interface ViewerSession {
+  readonly stop: () => Promise<void>;
+  readonly connections: ReadonlyMap<string, CameraConnection>;
+}
+
+export class StartViewerSessionUseCase {
+  constructor(private readonly deps: StartViewerSessionDeps) {}
+
+  async execute(input: StartViewerSessionInput): Promise<ViewerSession> {
+    const { signaling, connectToCamera, dashboardId, onPresenceSnapshot, onPresenceChange } =
+      this.deps;
+
+    if (!signaling.isConnected()) {
+      await signaling.connect();
+    }
+    signaling.registerPresence(dashboardId);
+
+    const cameraIds = input.bindings.map((b) => b.cameraId);
+    const connections = new Map<string, CameraConnection>();
+
+    if (cameraIds.length === 0) {
+      const noopHandler = (_change: PresenceChangeDto): void => undefined;
+      signaling.onPresenceChange(noopHandler);
+      return {
+        connections,
+        stop: async () => {
+          signaling.offPresenceChange(noopHandler);
+        },
+      };
+    }
+
+    signaling.subscribePresence(cameraIds);
+    const snapshot = await signaling.queryPresence(cameraIds);
+    onPresenceSnapshot(snapshot.online);
+
+    for (const cameraId of snapshot.online) {
+      try {
+        const conn = await connectToCamera.execute(cameraId);
+        connections.set(cameraId, conn);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn(`[viewer] failed to connect to ${cameraId}`, err);
+      }
+    }
+
+    const presenceHandler = (change: PresenceChangeDto): void => {
+      // The server only fans-out to subscribers, but accept and filter
+      // defensively so the use case stays robust.
+      if (!cameraIds.includes(change.peerId)) return;
+      onPresenceChange(change.peerId, change.online);
+
+      if (change.online) {
+        if (connections.has(change.peerId)) return;
+        void connectToCamera
+          .execute(change.peerId)
+          .then((conn) => connections.set(change.peerId, conn))
+          .catch((err) => {
+            // eslint-disable-next-line no-console
+            console.warn(`[viewer] reconnect failed for ${change.peerId}`, err);
+          });
+        return;
+      }
+
+      const existing = connections.get(change.peerId);
+      if (existing) {
+        existing.close();
+        connections.delete(change.peerId);
+      }
+    };
+
+    signaling.onPresenceChange(presenceHandler);
+
+    return {
+      connections,
+      stop: async () => {
+        signaling.offPresenceChange(presenceHandler);
+        for (const conn of connections.values()) conn.close();
+        connections.clear();
+      },
+    };
+  }
+}

--- a/apps/viewer/src/infrastructure/signaling/socketio-signaling.client.ts
+++ b/apps/viewer/src/infrastructure/signaling/socketio-signaling.client.ts
@@ -1,0 +1,134 @@
+// ============================================================
+// Socket.IO signaling client for the dashboard/viewer.
+// Implements the ISignalingRepository surface using the typed
+// event maps from @sentinel-monitor/shared-types.
+// ============================================================
+
+import { io, type Socket } from 'socket.io-client';
+import type {
+  IClientToServerEvents,
+  IServerToClientEvents,
+  PairingErrorDto,
+  PairingRedeemedDto,
+  PresenceChangeDto,
+  PresenceSnapshotDto,
+  SignalDto,
+} from '@sentinel-monitor/shared-types';
+import type {
+  ISignalingRepository,
+  RedeemPairingResult,
+} from '../../domain/repositories/i-signaling.repository';
+
+export type TypedSocket = Socket<IServerToClientEvents, IClientToServerEvents>;
+
+export interface SocketIoSignalingClientOptions {
+  readonly url: string;
+  readonly socketFactory?: (url: string) => TypedSocket;
+}
+
+const defaultFactory = (url: string): TypedSocket =>
+  io(url, {
+    autoConnect: false,
+    transports: ['websocket'],
+  }) as TypedSocket;
+
+function isPairingError(
+  response: PairingRedeemedDto | PairingErrorDto,
+): response is PairingErrorDto {
+  return (
+    typeof (response as PairingErrorDto).code === 'string' &&
+    typeof (response as PairingErrorDto).message === 'string' &&
+    (response as PairingRedeemedDto).cameraId === undefined
+  );
+}
+
+export class SocketIoSignalingClient implements ISignalingRepository {
+  private readonly socket: TypedSocket;
+
+  constructor(options: SocketIoSignalingClientOptions) {
+    const factory = options.socketFactory ?? defaultFactory;
+    this.socket = factory(options.url);
+  }
+
+  connect(): Promise<void> {
+    if (this.socket.connected) return Promise.resolve();
+    return new Promise<void>((resolve, reject) => {
+      const onConnect = (): void => {
+        this.socket.off('connect_error', onError);
+        resolve();
+      };
+      const onError = (err: Error): void => {
+        this.socket.off('connect', onConnect);
+        reject(err);
+      };
+      this.socket.once('connect', onConnect);
+      this.socket.once('connect_error', onError);
+      this.socket.connect();
+    });
+  }
+
+  disconnect(): void {
+    this.socket.disconnect();
+  }
+
+  isConnected(): boolean {
+    return this.socket.connected;
+  }
+
+  registerPresence(peerId: string): void {
+    this.socket.emit('register-presence', { peerId, role: 'dashboard' });
+  }
+
+  redeemPairingCode(
+    code: string,
+    dashboardId: string,
+  ): Promise<RedeemPairingResult> {
+    return new Promise<RedeemPairingResult>((resolve) => {
+      this.socket.emit(
+        'redeem-pairing-code',
+        { code, dashboardId },
+        (response: PairingRedeemedDto | PairingErrorDto) => {
+          if (isPairingError(response)) {
+            resolve({ success: false, error: response });
+            return;
+          }
+          resolve({ success: true, data: response });
+        },
+      );
+    });
+  }
+
+  queryPresence(peerIds: readonly string[]): Promise<PresenceSnapshotDto> {
+    return new Promise<PresenceSnapshotDto>((resolve) => {
+      this.socket.emit(
+        'query-presence',
+        { peerIds },
+        (response: PresenceSnapshotDto) => resolve(response),
+      );
+    });
+  }
+
+  subscribePresence(peerIds: readonly string[]): void {
+    this.socket.emit('subscribe-presence', { peerIds });
+  }
+
+  sendSignal(signal: SignalDto): void {
+    this.socket.emit('signal', signal);
+  }
+
+  onSignal(handler: (signal: SignalDto) => void): void {
+    this.socket.on('signal', handler);
+  }
+
+  offSignal(handler: (signal: SignalDto) => void): void {
+    this.socket.off('signal', handler);
+  }
+
+  onPresenceChange(handler: (change: PresenceChangeDto) => void): void {
+    this.socket.on('presence-change', handler);
+  }
+
+  offPresenceChange(handler: (change: PresenceChangeDto) => void): void {
+    this.socket.off('presence-change', handler);
+  }
+}

--- a/apps/viewer/src/infrastructure/webrtc/webrtc-subscriber.native.ts
+++ b/apps/viewer/src/infrastructure/webrtc/webrtc-subscriber.native.ts
@@ -1,0 +1,42 @@
+// ============================================================
+// Native subscriber stub. Real implementation lands in PR7
+// (react-native-webrtc). Constructing this on a native runtime
+// throws so misconfigured DI surfaces immediately.
+// ============================================================
+
+import type {
+  IWebRtcSubscriberRepository,
+  SubscriberState,
+} from '../../domain/repositories/i-webrtc-subscriber.repository';
+
+export class NativeWebRtcSubscriber implements IWebRtcSubscriberRepository {
+  constructor() {
+    throw new Error(
+      'NativeWebRtcSubscriber not implemented yet — see PR7 (react-native-webrtc)',
+    );
+  }
+
+  connect(_cameraId: string): Promise<void> {
+    throw new Error('not implemented — see PR7');
+  }
+
+  handleIncomingSignal(): Promise<void> {
+    throw new Error('not implemented — see PR7');
+  }
+
+  close(): void {
+    throw new Error('not implemented — see PR7');
+  }
+
+  onTrack(_handler: (stream: MediaStream) => void): void {
+    throw new Error('not implemented — see PR7');
+  }
+
+  onStateChange(_handler: (state: SubscriberState) => void): void {
+    throw new Error('not implemented — see PR7');
+  }
+
+  getState(): SubscriberState {
+    throw new Error('not implemented — see PR7');
+  }
+}

--- a/apps/viewer/src/infrastructure/webrtc/webrtc-subscriber.web.ts
+++ b/apps/viewer/src/infrastructure/webrtc/webrtc-subscriber.web.ts
@@ -1,0 +1,127 @@
+// ============================================================
+// Browser RTCPeerConnection-based subscriber. The dashboard is
+// the offerer in our protocol; the camera answers. We add a
+// recvonly transceiver pair (video + audio) so the SDP advertises
+// what we want, then send the offer through the injected signal sink.
+// ============================================================
+
+import { WEBRTC_CONFIG } from '@sentinel-monitor/webrtc-config';
+import type { SignalPayload } from '@sentinel-monitor/shared-types';
+import type {
+  IWebRtcSubscriberRepository,
+  SubscriberState,
+} from '../../domain/repositories/i-webrtc-subscriber.repository';
+
+export type PeerFactory = (config: RTCConfiguration) => RTCPeerConnection;
+
+export interface BrowserWebRtcSubscriberOptions {
+  readonly emitSignal: (payload: SignalPayload) => void;
+  readonly rtcConfig?: RTCConfiguration;
+  readonly peerFactory?: PeerFactory;
+}
+
+export class BrowserWebRtcSubscriber implements IWebRtcSubscriberRepository {
+  private readonly pc: RTCPeerConnection;
+  private state: SubscriberState = 'idle';
+  private remoteStream: MediaStream | null = null;
+  private trackHandler: ((stream: MediaStream) => void) | null = null;
+  private stateHandler: ((state: SubscriberState) => void) | null = null;
+
+  constructor(private readonly options: BrowserWebRtcSubscriberOptions) {
+    const factory = options.peerFactory ?? ((c) => new RTCPeerConnection(c));
+    this.pc = factory(options.rtcConfig ?? WEBRTC_CONFIG);
+
+    this.pc.ontrack = (event): void => {
+      // Prefer the stream the remote attached the track to. Fallback
+      // to a synthesized one for engines that omit event.streams.
+      const stream = event.streams[0] ?? new MediaStream([event.track]);
+      this.remoteStream = stream;
+      this.trackHandler?.(stream);
+    };
+
+    this.pc.onicecandidate = (event): void => {
+      if (event.candidate) {
+        this.options.emitSignal({
+          type: 'ice-candidate',
+          candidate: event.candidate.toJSON(),
+        });
+      }
+    };
+
+    this.pc.onconnectionstatechange = (): void => {
+      this.setState(mapPeerState(this.pc.connectionState));
+    };
+  }
+
+  async connect(_cameraId: string): Promise<void> {
+    this.setState('connecting');
+    // recvonly transceivers — we don't send media, we only receive.
+    this.pc.addTransceiver('video', { direction: 'recvonly' });
+    this.pc.addTransceiver('audio', { direction: 'recvonly' });
+
+    const offer = await this.pc.createOffer();
+    await this.pc.setLocalDescription(offer);
+    this.options.emitSignal({ type: 'offer', sdp: offer.sdp ?? '' });
+  }
+
+  async handleIncomingSignal(payload: SignalPayload): Promise<void> {
+    if (payload.type === 'answer') {
+      await this.pc.setRemoteDescription(
+        new RTCSessionDescription({ type: 'answer', sdp: payload.sdp }),
+      );
+      return;
+    }
+    if (payload.type === 'ice-candidate') {
+      try {
+        await this.pc.addIceCandidate(new RTCIceCandidate(payload.candidate));
+      } catch {
+        // Late or duplicate candidate — safe to ignore.
+      }
+      return;
+    }
+    // 'offer' arriving at the dashboard would be a protocol bug; ignore.
+  }
+
+  close(): void {
+    this.pc.close();
+    this.setState('closed');
+  }
+
+  onTrack(handler: (stream: MediaStream) => void): void {
+    this.trackHandler = handler;
+    if (this.remoteStream) handler(this.remoteStream);
+  }
+
+  onStateChange(handler: (state: SubscriberState) => void): void {
+    this.stateHandler = handler;
+  }
+
+  getState(): SubscriberState {
+    return this.state;
+  }
+
+  private setState(next: SubscriberState): void {
+    if (this.state === next) return;
+    this.state = next;
+    this.stateHandler?.(next);
+  }
+}
+
+function mapPeerState(s: RTCPeerConnectionState): SubscriberState {
+  switch (s) {
+    case 'new':
+      return 'idle';
+    case 'connecting':
+      return 'connecting';
+    case 'connected':
+      return 'connected';
+    case 'disconnected':
+      return 'disconnected';
+    case 'failed':
+      return 'failed';
+    case 'closed':
+      return 'closed';
+    default:
+      return 'idle';
+  }
+}

--- a/apps/viewer/src/presentation/bootstrap.ts
+++ b/apps/viewer/src/presentation/bootstrap.ts
@@ -1,35 +1,176 @@
 // ============================================================
 // App-level bootstrap — wires the platform-specific storage
-// into the bindings store singleton. Imported once from the
-// root layout.
+// into the bindings store singleton, builds the realtime stack
+// (signaling, peers, presence) and starts the viewer session.
+// Imported once from the root layout.
 // ============================================================
 
+import { SIGNALING_URL } from '@sentinel-monitor/webrtc-config';
+import type { ConnectionState } from '@sentinel-monitor/shared-types';
+import { ConnectToCameraUseCase } from '@/domain/use-cases/connect-to-camera.use-case';
+import { StartViewerSessionUseCase } from '@/domain/use-cases/start-viewer-session.use-case';
+import type { ISignalingRepository } from '@/domain/repositories/i-signaling.repository';
+import type { SubscriberState } from '@/domain/repositories/i-webrtc-subscriber.repository';
 import { createBindingStorage } from '@/infrastructure/storage/binding-storage';
+import { SocketIoSignalingClient } from '@/infrastructure/signaling/socketio-signaling.client';
+import { BrowserWebRtcSubscriber } from '@/infrastructure/webrtc/webrtc-subscriber.web';
 import {
   createBindingsStore,
   setBindingsStoreSingleton,
   type BindingsStore,
 } from './stores/bindings.store';
+import {
+  createPresenceStore,
+  setPresenceStoreSingleton,
+  type PresenceStore,
+} from './stores/presence.store';
+import {
+  createPeersStore,
+  setPeersStoreSingleton,
+  type PeersStore,
+} from './stores/peers.store';
 
-let initialized: BindingsStore | null = null;
+export interface ViewerRuntime {
+  readonly bindings: BindingsStore;
+  readonly presence: PresenceStore;
+  readonly peers: PeersStore;
+  readonly signaling: ISignalingRepository;
+  readonly start: () => Promise<void>;
+  readonly stop: () => Promise<void>;
+}
+
+let runtime: ViewerRuntime | null = null;
 
 function generateId(): string {
-  // crypto.randomUUID is available on modern web + RN 0.74+.
   if (typeof globalThis.crypto?.randomUUID === 'function') {
     return globalThis.crypto.randomUUID();
   }
   return `id-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-export function initBindingsStore(): BindingsStore {
-  if (initialized) return initialized;
+function mapSubscriberState(state: SubscriberState): ConnectionState {
+  switch (state) {
+    case 'connected':
+      return 'connected';
+    case 'connecting':
+      return 'connecting';
+    case 'disconnected':
+    case 'failed':
+    case 'closed':
+      return 'disconnected';
+    case 'idle':
+    default:
+      return 'idle';
+  }
+}
+
+export function initRuntime(): ViewerRuntime {
+  if (runtime) return runtime;
+
   const storage = createBindingStorage();
-  const store = createBindingsStore({
+  const presence = createPresenceStore();
+  const peers = createPeersStore();
+  const signaling: ISignalingRepository = new SocketIoSignalingClient({
+    url: SIGNALING_URL,
+  });
+
+  setPresenceStoreSingleton(presence);
+  setPeersStoreSingleton(peers);
+
+  // Pairing-code → cameraId resolution cache. Populated by addCamera
+  // once the server confirms redemption; consumed by the bindings
+  // store's resolveCameraId hook (which must stay synchronous).
+  const resolveCache = new Map<string, string>();
+
+  const bindings = createBindingsStore({
     storage,
     generateId,
     now: () => Date.now(),
+    resolveCameraId: (code) => {
+      const cached = resolveCache.get(code.toUpperCase());
+      if (cached) return cached;
+      // Fallback for offline scenarios — keeps the store usable
+      // without a live server.
+      return `camera-${code.toUpperCase()}`;
+    },
   });
-  setBindingsStoreSingleton(store);
-  initialized = store;
-  return store;
+  setBindingsStoreSingleton(bindings);
+
+  let dashboardId = '';
+
+  const connectToCamera = new ConnectToCameraUseCase({
+    signaling,
+    get dashboardId(): string {
+      return dashboardId;
+    },
+    subscriberFactory: (_cameraId, emitSignal) =>
+      new BrowserWebRtcSubscriber({ emitSignal }),
+    onStream: (cameraId, stream) =>
+      peers.getState().setStream(cameraId, stream),
+    onState: (cameraId, state) =>
+      peers.getState().setState(cameraId, mapSubscriberState(state)),
+  });
+
+  // Wrap addCamera so that pairing redemption + connect happen alongside
+  // persistence. Falls back to the offline path when signaling is down.
+  const baseAdd = bindings.getState().addCamera;
+  bindings.setState({
+    addCamera: async (input) => {
+      const code = input.pairingCode.trim().toUpperCase();
+      if (signaling.isConnected() && dashboardId) {
+        const result = await signaling.redeemPairingCode(code, dashboardId);
+        if (!result.success) {
+          throw new Error(`pairing failed: ${result.error.message}`);
+        }
+        resolveCache.set(code, result.data.cameraId);
+      }
+      const next = await baseAdd(input);
+      if (signaling.isConnected() && dashboardId) {
+        signaling.subscribePresence([next.cameraId]);
+        const snap = await signaling.queryPresence([next.cameraId]);
+        if (snap.online.includes(next.cameraId)) {
+          presence.getState().setOne(next.cameraId, true);
+          await connectToCamera.execute(next.cameraId);
+        }
+      }
+      return next;
+    },
+  });
+
+  let session: { stop: () => Promise<void> } | null = null;
+
+  const start = async (): Promise<void> => {
+    await bindings.getState().hydrate();
+    const identity = bindings.getState().identity;
+    if (!identity) throw new Error('viewer identity not hydrated');
+    dashboardId = identity.dashboardId;
+
+    const sessionUC = new StartViewerSessionUseCase({
+      signaling,
+      connectToCamera,
+      dashboardId,
+      onPresenceSnapshot: (online) => presence.getState().setMany(online),
+      onPresenceChange: (cameraId, online) => {
+        presence.getState().setOne(cameraId, online);
+        if (!online) peers.getState().remove(cameraId);
+      },
+    });
+    session = await sessionUC.execute({
+      bindings: bindings.getState().bindings,
+    });
+  };
+
+  const stop = async (): Promise<void> => {
+    await session?.stop();
+    session = null;
+    signaling.disconnect();
+  };
+
+  runtime = { bindings, presence, peers, signaling, start, stop };
+  return runtime;
+}
+
+// Backwards-compatible export retained for existing callers.
+export function initBindingsStore(): BindingsStore {
+  return initRuntime().bindings;
 }

--- a/apps/viewer/src/presentation/components/camera-tile.component.tsx
+++ b/apps/viewer/src/presentation/components/camera-tile.component.tsx
@@ -1,20 +1,55 @@
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import type { CameraBindingEntity } from '@/domain/entities/camera-binding.entity';
+import type { ConnectionState } from '@sentinel-monitor/shared-types';
 import { getStatusColor, radii, semantic, spacing, typography } from '../theme';
+import { VideoSurface } from './video-surface';
 
 export interface CameraTileProps {
   readonly binding: CameraBindingEntity;
+  readonly stream?: MediaStream | null;
+  readonly state?: ConnectionState;
+  readonly online?: boolean;
   readonly onPress?: () => void;
   readonly onLongPress?: () => void;
 }
 
+function resolveStatus(
+  online: boolean | undefined,
+  state: ConnectionState | undefined,
+): ConnectionState {
+  if (online === false) return 'offline';
+  return state ?? 'idle';
+}
+
+function statusLabel(status: ConnectionState): string {
+  switch (status) {
+    case 'connected':
+      return 'Ao vivo';
+    case 'connecting':
+      return 'Conectando…';
+    case 'reconnecting':
+      return 'Reconectando…';
+    case 'offline':
+      return 'Offline';
+    case 'disconnected':
+      return 'Desconectado';
+    case 'idle':
+    default:
+      return 'Aguardando vídeo…';
+  }
+}
+
 export function CameraTile({
   binding,
+  stream = null,
+  state,
+  online,
   onPress,
   onLongPress,
 }: CameraTileProps): JSX.Element {
-  // PR6 will replace 'idle' with the live ConnectionState.
-  const statusColor = getStatusColor('idle');
+  const status = resolveStatus(online, state);
+  const statusColor = getStatusColor(status);
+  const showVideo = status === 'connected' && stream !== null;
 
   return (
     <TouchableOpacity
@@ -24,10 +59,19 @@ export function CameraTile({
       accessibilityLabel={`camera-tile-${binding.id}`}
     >
       <View style={styles.placeholder}>
-        <Text style={styles.placeholderText}>Aguardando vídeo…</Text>
+        {showVideo ? (
+          <View style={StyleSheet.absoluteFill}>
+            <VideoSurface stream={stream} muted={false} />
+          </View>
+        ) : (
+          <Text style={styles.placeholderText}>{statusLabel(status)}</Text>
+        )}
       </View>
       <View style={styles.footer}>
-        <View style={[styles.statusDot, { backgroundColor: statusColor }]} />
+        <View
+          style={[styles.statusDot, { backgroundColor: statusColor }]}
+          accessibilityLabel={`presence-dot-${status}`}
+        />
         <Text style={styles.label} numberOfLines={1}>
           {binding.label}
         </Text>

--- a/apps/viewer/src/presentation/components/video-surface.native.tsx
+++ b/apps/viewer/src/presentation/components/video-surface.native.tsx
@@ -1,0 +1,19 @@
+// ============================================================
+// Native video surface — STUB. The real implementation arrives
+// in PR7 alongside react-native-webrtc's RTCView.
+// ============================================================
+
+import type { ReactElement } from 'react';
+
+export interface VideoSurfaceProps {
+  readonly stream: MediaStream | null;
+  readonly muted?: boolean;
+}
+
+export function VideoSurface(_props: VideoSurfaceProps): ReactElement | null {
+  // eslint-disable-next-line no-console
+  console.warn(
+    'VideoSurface (native): not implemented — see PR7 (react-native-webrtc / RTCView)',
+  );
+  return null;
+}

--- a/apps/viewer/src/presentation/components/video-surface.tsx
+++ b/apps/viewer/src/presentation/components/video-surface.tsx
@@ -1,0 +1,17 @@
+// ============================================================
+// Stub fallback used only by Jest (which does not honor Metro's
+// .web/.native extension resolution by default). Production web
+// builds resolve video-surface.web.tsx; native builds resolve
+// video-surface.native.tsx.
+// ============================================================
+
+import type { ReactElement } from 'react';
+
+export interface VideoSurfaceProps {
+  readonly stream: MediaStream | null;
+  readonly muted?: boolean;
+}
+
+export function VideoSurface(_props: VideoSurfaceProps): ReactElement | null {
+  return null;
+}

--- a/apps/viewer/src/presentation/components/video-surface.web.tsx
+++ b/apps/viewer/src/presentation/components/video-surface.web.tsx
@@ -1,0 +1,42 @@
+// ============================================================
+// Web video surface — wraps a native <video> element and binds the
+// inbound MediaStream to its srcObject. Falls back gracefully when
+// stream is null.
+// ============================================================
+
+import { useEffect, useRef } from 'react';
+
+export interface VideoSurfaceProps {
+  readonly stream: MediaStream | null;
+  readonly muted?: boolean;
+}
+
+export function VideoSurface({
+  stream,
+  muted = false,
+}: VideoSurfaceProps): JSX.Element {
+  const ref = useRef<HTMLVideoElement | null>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (el.srcObject !== stream) {
+      el.srcObject = stream;
+    }
+  }, [stream]);
+
+  return (
+    <video
+      ref={ref}
+      autoPlay
+      playsInline
+      muted={muted}
+      style={{
+        width: '100%',
+        height: '100%',
+        objectFit: 'cover',
+        backgroundColor: '#000',
+      }}
+    />
+  );
+}

--- a/apps/viewer/src/presentation/stores/peers.store.ts
+++ b/apps/viewer/src/presentation/stores/peers.store.ts
@@ -1,0 +1,85 @@
+// ============================================================
+// peers.store — Map<cameraId, PeerEntry> with the live MediaStream
+// and connection state. Built around an internal Map for fast lookup;
+// the .entries view is rebuilt on each change so React selectors can
+// shallow-compare.
+// ============================================================
+
+import { createStore, useStore } from 'zustand';
+import type { ConnectionState } from '@sentinel-monitor/shared-types';
+
+export interface PeerEntry {
+  readonly cameraId: string;
+  readonly stream: MediaStream | null;
+  readonly state: ConnectionState;
+}
+
+export interface PeersState {
+  readonly peers: Readonly<Record<string, PeerEntry>>;
+  readonly setStream: (cameraId: string, stream: MediaStream) => void;
+  readonly setState: (cameraId: string, state: ConnectionState) => void;
+  readonly remove: (cameraId: string) => void;
+  readonly get: (cameraId: string) => PeerEntry | undefined;
+  readonly clear: () => void;
+}
+
+export function createPeersStore() {
+  return createStore<PeersState>((set, get) => ({
+    peers: {},
+
+    setStream: (cameraId, stream) => {
+      const current = get().peers;
+      const existing = current[cameraId];
+      const next: PeerEntry = {
+        cameraId,
+        stream,
+        state: existing?.state ?? 'connected',
+      };
+      set({ peers: { ...current, [cameraId]: next } });
+    },
+
+    setState: (cameraId, state) => {
+      const current = get().peers;
+      const existing = current[cameraId];
+      const next: PeerEntry = {
+        cameraId,
+        stream: existing?.stream ?? null,
+        state,
+      };
+      set({ peers: { ...current, [cameraId]: next } });
+    },
+
+    remove: (cameraId) => {
+      const current = get().peers;
+      if (!(cameraId in current)) return;
+      const next = { ...current };
+      delete next[cameraId];
+      set({ peers: next });
+    },
+
+    get: (cameraId) => get().peers[cameraId],
+
+    clear: () => set({ peers: {} }),
+  }));
+}
+
+export type PeersStore = ReturnType<typeof createPeersStore>;
+
+let singleton: PeersStore | null = null;
+
+export function setPeersStoreSingleton(store: PeersStore): void {
+  singleton = store;
+}
+
+export function getPeersStoreSingleton(): PeersStore {
+  if (!singleton) {
+    throw new Error(
+      'peers store not initialized — call setPeersStoreSingleton() in app bootstrap',
+    );
+  }
+  return singleton;
+}
+
+export function usePeersStore<T>(selector: (state: PeersState) => T): T {
+  return useStore(getPeersStoreSingleton(), selector);
+}

--- a/apps/viewer/src/presentation/stores/presence.store.ts
+++ b/apps/viewer/src/presentation/stores/presence.store.ts
@@ -1,0 +1,59 @@
+// ============================================================
+// presence.store — tracks which cameraIds are currently online
+// from the dashboard's perspective.
+//
+// Pattern mirrors bindings.store (createStore + singleton + hook).
+// ============================================================
+
+import { createStore, useStore } from 'zustand';
+
+export interface PresenceState {
+  readonly online: Readonly<Record<string, boolean>>;
+  readonly setMany: (cameraIds: readonly string[]) => void;
+  readonly setOne: (cameraId: string, online: boolean) => void;
+  readonly isOnline: (cameraId: string) => boolean;
+  readonly reset: () => void;
+}
+
+export function createPresenceStore() {
+  return createStore<PresenceState>((set, get) => ({
+    online: {},
+
+    setMany: (cameraIds) => {
+      const next: Record<string, boolean> = {};
+      for (const id of cameraIds) next[id] = true;
+      set({ online: next });
+    },
+
+    setOne: (cameraId, online) => {
+      const current = get().online;
+      if (Boolean(current[cameraId]) === online) return;
+      set({ online: { ...current, [cameraId]: online } });
+    },
+
+    isOnline: (cameraId) => Boolean(get().online[cameraId]),
+
+    reset: () => set({ online: {} }),
+  }));
+}
+
+export type PresenceStore = ReturnType<typeof createPresenceStore>;
+
+let singleton: PresenceStore | null = null;
+
+export function setPresenceStoreSingleton(store: PresenceStore): void {
+  singleton = store;
+}
+
+export function getPresenceStoreSingleton(): PresenceStore {
+  if (!singleton) {
+    throw new Error(
+      'presence store not initialized — call setPresenceStoreSingleton() in app bootstrap',
+    );
+  }
+  return singleton;
+}
+
+export function usePresenceStore<T>(selector: (state: PresenceState) => T): T {
+  return useStore(getPresenceStoreSingleton(), selector);
+}

--- a/apps/viewer/tests/unit/connect-to-camera.use-case.test.ts
+++ b/apps/viewer/tests/unit/connect-to-camera.use-case.test.ts
@@ -1,0 +1,203 @@
+import {
+  ConnectToCameraUseCase,
+  type SubscriberFactory,
+} from '@/domain/use-cases/connect-to-camera.use-case';
+import type { ISignalingRepository } from '@/domain/repositories/i-signaling.repository';
+import type {
+  IWebRtcSubscriberRepository,
+  SubscriberState,
+} from '@/domain/repositories/i-webrtc-subscriber.repository';
+import type {
+  SignalDto,
+  SignalPayload,
+} from '@sentinel-monitor/shared-types';
+
+interface FakeSubscriber extends IWebRtcSubscriberRepository {
+  trackHandler: ((stream: MediaStream) => void) | null;
+  stateHandler: ((state: SubscriberState) => void) | null;
+  emitSignal: (payload: SignalPayload) => void;
+  cameraIdAtConnect: string | null;
+  closed: boolean;
+  incoming: SignalPayload[];
+  connectImpl: (() => Promise<void>) | null;
+}
+
+function createFakeSubscriber(emit: (p: SignalPayload) => void): FakeSubscriber {
+  let state: SubscriberState = 'idle';
+  const sub: FakeSubscriber = {
+    trackHandler: null,
+    stateHandler: null,
+    emitSignal: emit,
+    cameraIdAtConnect: null,
+    closed: false,
+    incoming: [],
+    connectImpl: null,
+    async connect(cameraId: string) {
+      sub.cameraIdAtConnect = cameraId;
+      if (sub.connectImpl) await sub.connectImpl();
+    },
+    async handleIncomingSignal(payload: SignalPayload) {
+      sub.incoming.push(payload);
+    },
+    close() {
+      sub.closed = true;
+    },
+    onTrack(handler) {
+      sub.trackHandler = handler;
+    },
+    onStateChange(handler) {
+      sub.stateHandler = handler;
+    },
+    getState() {
+      return state;
+    },
+  };
+  void state;
+  return sub;
+}
+
+interface FakeSignaling {
+  signalHandlers: Array<(s: SignalDto) => void>;
+  presenceHandlers: Array<(c: { peerId: string; online: boolean }) => void>;
+  sent: SignalDto[];
+  repo: ISignalingRepository;
+}
+
+function createFakeSignaling(): FakeSignaling {
+  const f: FakeSignaling = {
+    signalHandlers: [],
+    presenceHandlers: [],
+    sent: [],
+    repo: {} as ISignalingRepository,
+  };
+  f.repo = {
+    connect: async () => undefined,
+    disconnect: () => undefined,
+    isConnected: () => true,
+    registerPresence: () => undefined,
+    redeemPairingCode: async () => ({
+      success: true,
+      data: { cameraId: 'c', dashboardId: 'd' },
+    }),
+    queryPresence: async () => ({ online: [] }),
+    subscribePresence: () => undefined,
+    sendSignal: (s) => f.sent.push(s),
+    onSignal: (h) => {
+      f.signalHandlers.push(h);
+    },
+    offSignal: (h) => {
+      f.signalHandlers = f.signalHandlers.filter((x) => x !== h);
+    },
+    onPresenceChange: (h) => {
+      f.presenceHandlers.push(h);
+    },
+    offPresenceChange: (h) => {
+      f.presenceHandlers = f.presenceHandlers.filter((x) => x !== h);
+    },
+  };
+  return f;
+}
+
+function buildUseCase(): {
+  uc: ConnectToCameraUseCase;
+  signaling: FakeSignaling;
+  subscribers: FakeSubscriber[];
+  streams: Array<{ cameraId: string; stream: MediaStream }>;
+  states: Array<{ cameraId: string; state: SubscriberState }>;
+  factory: SubscriberFactory;
+} {
+  const signaling = createFakeSignaling();
+  const subscribers: FakeSubscriber[] = [];
+  const streams: Array<{ cameraId: string; stream: MediaStream }> = [];
+  const states: Array<{ cameraId: string; state: SubscriberState }> = [];
+  const factory: SubscriberFactory = (cameraId, emitSignal) => {
+    const s = createFakeSubscriber(emitSignal);
+    subscribers.push(s);
+    void cameraId;
+    return s;
+  };
+  const uc = new ConnectToCameraUseCase({
+    signaling: signaling.repo,
+    subscriberFactory: factory,
+    dashboardId: 'dash-1',
+    onStream: (cameraId, stream) => streams.push({ cameraId, stream }),
+    onState: (cameraId, state) => states.push({ cameraId, state }),
+  });
+  return { uc, signaling, subscribers, streams, states, factory };
+}
+
+describe('ConnectToCameraUseCase', () => {
+  it('builds a subscriber, wires signal handler and triggers connect', async () => {
+    const { uc, signaling, subscribers, states } = buildUseCase();
+    const conn = await uc.execute('camera-1');
+    expect(subscribers).toHaveLength(1);
+    expect(subscribers[0]!.cameraIdAtConnect).toBe('camera-1');
+    expect(signaling.signalHandlers).toHaveLength(1);
+    expect(states[0]).toEqual({ cameraId: 'camera-1', state: 'connecting' });
+    expect(conn.cameraId).toBe('camera-1');
+    expect(conn.subscriber).toBe(subscribers[0]);
+  });
+
+  it('emitSignal wraps payload with from/to peer ids', async () => {
+    const { uc, signaling, subscribers } = buildUseCase();
+    await uc.execute('camera-1');
+    subscribers[0]!.emitSignal({ type: 'offer', sdp: 'v=0' });
+    expect(signaling.sent).toEqual([
+      {
+        fromPeerId: 'dash-1',
+        toPeerId: 'camera-1',
+        payload: { type: 'offer', sdp: 'v=0' },
+      },
+    ]);
+  });
+
+  it('forwards inbound signals from the matching peer to the subscriber', async () => {
+    const { uc, signaling, subscribers } = buildUseCase();
+    await uc.execute('camera-1');
+    const handler = signaling.signalHandlers[0]!;
+    handler({
+      fromPeerId: 'camera-1',
+      toPeerId: 'dash-1',
+      payload: { type: 'answer', sdp: 'v=0' },
+    });
+    // Drain microtask
+    await Promise.resolve();
+    expect(subscribers[0]!.incoming).toEqual([{ type: 'answer', sdp: 'v=0' }]);
+  });
+
+  it('ignores inbound signals from other peers', async () => {
+    const { uc, signaling, subscribers } = buildUseCase();
+    await uc.execute('camera-1');
+    signaling.signalHandlers[0]!({
+      fromPeerId: 'camera-OTHER',
+      toPeerId: 'dash-1',
+      payload: { type: 'answer', sdp: '' },
+    });
+    await Promise.resolve();
+    expect(subscribers[0]!.incoming).toHaveLength(0);
+  });
+
+  it('forwards onTrack into onStream callback', async () => {
+    const { uc, subscribers, streams } = buildUseCase();
+    await uc.execute('camera-1');
+    const fakeStream = { id: 's' } as unknown as MediaStream;
+    subscribers[0]!.trackHandler!(fakeStream);
+    expect(streams).toEqual([{ cameraId: 'camera-1', stream: fakeStream }]);
+  });
+
+  it('forwards onStateChange into onState callback', async () => {
+    const { uc, subscribers, states } = buildUseCase();
+    await uc.execute('camera-1');
+    subscribers[0]!.stateHandler!('connected');
+    expect(states).toContainEqual({ cameraId: 'camera-1', state: 'connected' });
+  });
+
+  it('close() detaches signal handler, closes subscriber, emits closed state', async () => {
+    const { uc, signaling, subscribers, states } = buildUseCase();
+    const conn = await uc.execute('camera-1');
+    conn.close();
+    expect(signaling.signalHandlers).toHaveLength(0);
+    expect(subscribers[0]!.closed).toBe(true);
+    expect(states.at(-1)).toEqual({ cameraId: 'camera-1', state: 'closed' });
+  });
+});

--- a/apps/viewer/tests/unit/peers.store.test.ts
+++ b/apps/viewer/tests/unit/peers.store.test.ts
@@ -1,0 +1,93 @@
+import {
+  createPeersStore,
+  setPeersStoreSingleton,
+  getPeersStoreSingleton,
+} from '@/presentation/stores/peers.store';
+
+const fakeStream = (): MediaStream =>
+  ({ id: 'stream' } as unknown as MediaStream);
+
+describe('peers.store', () => {
+  it('starts empty', () => {
+    const store = createPeersStore();
+    expect(store.getState().peers).toEqual({});
+    expect(store.getState().get('camera-1')).toBeUndefined();
+  });
+
+  it('setStream creates an entry with default state "connected"', () => {
+    const store = createPeersStore();
+    const s = fakeStream();
+    store.getState().setStream('camera-1', s);
+    const entry = store.getState().get('camera-1');
+    expect(entry).toEqual({
+      cameraId: 'camera-1',
+      stream: s,
+      state: 'connected',
+    });
+  });
+
+  it('setStream preserves existing state if already set', () => {
+    const store = createPeersStore();
+    store.getState().setState('camera-1', 'connecting');
+    const s = fakeStream();
+    store.getState().setStream('camera-1', s);
+    expect(store.getState().get('camera-1')!.state).toBe('connecting');
+    expect(store.getState().get('camera-1')!.stream).toBe(s);
+  });
+
+  it('setState creates an entry with null stream when none exists', () => {
+    const store = createPeersStore();
+    store.getState().setState('camera-2', 'idle');
+    expect(store.getState().get('camera-2')).toEqual({
+      cameraId: 'camera-2',
+      stream: null,
+      state: 'idle',
+    });
+  });
+
+  it('setState preserves the existing stream', () => {
+    const store = createPeersStore();
+    const s = fakeStream();
+    store.getState().setStream('camera-1', s);
+    store.getState().setState('camera-1', 'reconnecting');
+    expect(store.getState().get('camera-1')!.stream).toBe(s);
+    expect(store.getState().get('camera-1')!.state).toBe('reconnecting');
+  });
+
+  it('remove deletes an entry', () => {
+    const store = createPeersStore();
+    store.getState().setState('camera-1', 'connected');
+    store.getState().remove('camera-1');
+    expect(store.getState().get('camera-1')).toBeUndefined();
+  });
+
+  it('remove is a noop for unknown ids', () => {
+    const store = createPeersStore();
+    const before = store.getState().peers;
+    store.getState().remove('nope');
+    expect(store.getState().peers).toBe(before);
+  });
+
+  it('clear empties everything', () => {
+    const store = createPeersStore();
+    store.getState().setState('a', 'connected');
+    store.getState().setState('b', 'connected');
+    store.getState().clear();
+    expect(store.getState().peers).toEqual({});
+  });
+});
+
+describe('peers.store singleton helpers', () => {
+  it('getPeersStoreSingleton throws when not initialized', () => {
+    jest.isolateModules(() => {
+      const mod = require('@/presentation/stores/peers.store');
+      expect(() => mod.getPeersStoreSingleton()).toThrow(/not initialized/);
+    });
+  });
+
+  it('set + get returns the same store', () => {
+    const store = createPeersStore();
+    setPeersStoreSingleton(store);
+    expect(getPeersStoreSingleton()).toBe(store);
+  });
+});

--- a/apps/viewer/tests/unit/presence.store.test.ts
+++ b/apps/viewer/tests/unit/presence.store.test.ts
@@ -1,0 +1,66 @@
+import {
+  createPresenceStore,
+  setPresenceStoreSingleton,
+  getPresenceStoreSingleton,
+} from '@/presentation/stores/presence.store';
+
+describe('presence.store', () => {
+  it('starts with no online peers', () => {
+    const store = createPresenceStore();
+    expect(store.getState().online).toEqual({});
+    expect(store.getState().isOnline('camera-1')).toBe(false);
+  });
+
+  it('setMany marks every id as online and replaces previous state', () => {
+    const store = createPresenceStore();
+    store.getState().setOne('old', true);
+    store.getState().setMany(['a', 'b', 'c']);
+    expect(store.getState().online).toEqual({ a: true, b: true, c: true });
+    expect(store.getState().isOnline('old')).toBe(false);
+  });
+
+  it('setMany with empty array clears online', () => {
+    const store = createPresenceStore();
+    store.getState().setOne('x', true);
+    store.getState().setMany([]);
+    expect(store.getState().online).toEqual({});
+  });
+
+  it('setOne flips a peer online and offline', () => {
+    const store = createPresenceStore();
+    store.getState().setOne('camera-1', true);
+    expect(store.getState().isOnline('camera-1')).toBe(true);
+    store.getState().setOne('camera-1', false);
+    expect(store.getState().isOnline('camera-1')).toBe(false);
+  });
+
+  it('setOne is a noop when value does not change (same reference)', () => {
+    const store = createPresenceStore();
+    store.getState().setOne('camera-1', true);
+    const ref = store.getState().online;
+    store.getState().setOne('camera-1', true);
+    expect(store.getState().online).toBe(ref);
+  });
+
+  it('reset clears online', () => {
+    const store = createPresenceStore();
+    store.getState().setMany(['a', 'b']);
+    store.getState().reset();
+    expect(store.getState().online).toEqual({});
+  });
+});
+
+describe('presence.store singleton helpers', () => {
+  it('getPresenceStoreSingleton throws when not initialized', () => {
+    jest.isolateModules(() => {
+      const mod = require('@/presentation/stores/presence.store');
+      expect(() => mod.getPresenceStoreSingleton()).toThrow(/not initialized/);
+    });
+  });
+
+  it('set + get returns the same store', () => {
+    const store = createPresenceStore();
+    setPresenceStoreSingleton(store);
+    expect(getPresenceStoreSingleton()).toBe(store);
+  });
+});

--- a/apps/viewer/tests/unit/socketio-signaling.client.test.ts
+++ b/apps/viewer/tests/unit/socketio-signaling.client.test.ts
@@ -1,0 +1,256 @@
+import {
+  SocketIoSignalingClient,
+  type TypedSocket,
+} from '@/infrastructure/signaling/socketio-signaling.client';
+import type {
+  PairingErrorDto,
+  PairingRedeemedDto,
+  PresenceChangeDto,
+  PresenceSnapshotDto,
+  SignalDto,
+} from '@sentinel-monitor/shared-types';
+
+interface FakeSocket {
+  connected: boolean;
+  emitted: Array<{ event: string; args: unknown[] }>;
+  listeners: Record<string, Array<(...a: unknown[]) => void>>;
+  onceListeners: Record<string, Array<(...a: unknown[]) => void>>;
+  socket: TypedSocket;
+}
+
+function createFakeSocket(): FakeSocket {
+  const f: FakeSocket = {
+    connected: false,
+    emitted: [],
+    listeners: {},
+    onceListeners: {},
+    socket: {} as TypedSocket,
+  };
+
+  const dispatch = (event: string, ...args: unknown[]): void => {
+    (f.listeners[event] ?? []).forEach((fn) => fn(...args));
+    const once = f.onceListeners[event] ?? [];
+    f.onceListeners[event] = [];
+    once.forEach((fn) => fn(...args));
+  };
+
+  f.socket = {
+    get connected() {
+      return f.connected;
+    },
+    connect: () => {
+      // emulate async connect
+      setTimeout(() => {
+        f.connected = true;
+        dispatch('connect');
+      }, 0);
+    },
+    disconnect: () => {
+      f.connected = false;
+    },
+    emit: (event: string, ...args: unknown[]) => {
+      f.emitted.push({ event, args });
+    },
+    on: (event: string, handler: (...a: unknown[]) => void) => {
+      (f.listeners[event] ??= []).push(handler);
+    },
+    off: (event: string, handler?: (...a: unknown[]) => void) => {
+      if (!handler) {
+        f.listeners[event] = [];
+        return;
+      }
+      f.listeners[event] = (f.listeners[event] ?? []).filter(
+        (h) => h !== handler,
+      );
+    },
+    once: (event: string, handler: (...a: unknown[]) => void) => {
+      (f.onceListeners[event] ??= []).push(handler);
+    },
+    // Test helper
+    __dispatch: dispatch,
+    __failConnect: (err: Error) => {
+      setTimeout(() => dispatch('connect_error', err), 0);
+    },
+  } as unknown as TypedSocket;
+  return f;
+}
+
+function buildClient(fake: FakeSocket): SocketIoSignalingClient {
+  return new SocketIoSignalingClient({
+    url: 'http://localhost:0',
+    socketFactory: () => fake.socket,
+  });
+}
+
+describe('SocketIoSignalingClient', () => {
+  it('uses the provided socketFactory with the configured URL', () => {
+    const fake = createFakeSocket();
+    let received = '';
+    const client = new SocketIoSignalingClient({
+      url: 'http://server:1234',
+      socketFactory: (url) => {
+        received = url;
+        return fake.socket;
+      },
+    });
+    expect(client).toBeDefined();
+    expect(received).toBe('http://server:1234');
+  });
+
+  it('connect() resolves when the socket emits "connect"', async () => {
+    const fake = createFakeSocket();
+    const client = buildClient(fake);
+    await client.connect();
+    expect(fake.connected).toBe(true);
+    expect(client.isConnected()).toBe(true);
+  });
+
+  it('connect() resolves immediately when already connected', async () => {
+    const fake = createFakeSocket();
+    fake.connected = true;
+    const client = buildClient(fake);
+    await client.connect(); // should not hang
+  });
+
+  it('connect() rejects when the socket emits "connect_error"', async () => {
+    const fake = createFakeSocket();
+    const client = buildClient(fake);
+    const err = new Error('fail');
+    setTimeout(
+      () =>
+        (
+          fake.socket as unknown as { __dispatch: (e: string, p: Error) => void }
+        ).__dispatch('connect_error', err),
+      0,
+    );
+    await expect(client.connect()).rejects.toBe(err);
+  });
+
+  it('disconnect() forwards to the underlying socket', () => {
+    const fake = createFakeSocket();
+    fake.connected = true;
+    const client = buildClient(fake);
+    client.disconnect();
+    expect(fake.connected).toBe(false);
+  });
+
+  it('registerPresence emits with role "dashboard"', () => {
+    const fake = createFakeSocket();
+    const client = buildClient(fake);
+    client.registerPresence('dash-1');
+    expect(fake.emitted).toEqual([
+      { event: 'register-presence', args: [{ peerId: 'dash-1', role: 'dashboard' }] },
+    ]);
+  });
+
+  it('redeemPairingCode emits the payload and resolves with success', async () => {
+    const fake = createFakeSocket();
+    const client = buildClient(fake);
+    const promise = client.redeemPairingCode('CODE', 'dash-1');
+    expect(fake.emitted[0]!.event).toBe('redeem-pairing-code');
+    expect(fake.emitted[0]!.args[0]).toEqual({ code: 'CODE', dashboardId: 'dash-1' });
+    const ack = fake.emitted[0]!.args[1] as (
+      r: PairingRedeemedDto | PairingErrorDto,
+    ) => void;
+    ack({ cameraId: 'cam-1', dashboardId: 'dash-1' });
+    const result = await promise;
+    expect(result).toEqual({
+      success: true,
+      data: { cameraId: 'cam-1', dashboardId: 'dash-1' },
+    });
+  });
+
+  it('redeemPairingCode resolves with error on PairingErrorDto', async () => {
+    const fake = createFakeSocket();
+    const client = buildClient(fake);
+    const promise = client.redeemPairingCode('CODE', 'dash-1');
+    const ack = fake.emitted[0]!.args[1] as (
+      r: PairingRedeemedDto | PairingErrorDto,
+    ) => void;
+    ack({ code: 'NOT_FOUND', message: 'no match' });
+    const result = await promise;
+    expect(result).toEqual({
+      success: false,
+      error: { code: 'NOT_FOUND', message: 'no match' },
+    });
+  });
+
+  it('queryPresence emits and resolves with the snapshot', async () => {
+    const fake = createFakeSocket();
+    const client = buildClient(fake);
+    const p = client.queryPresence(['a', 'b']);
+    expect(fake.emitted[0]!.event).toBe('query-presence');
+    expect(fake.emitted[0]!.args[0]).toEqual({ peerIds: ['a', 'b'] });
+    const ack = fake.emitted[0]!.args[1] as (r: PresenceSnapshotDto) => void;
+    ack({ online: ['a'] });
+    await expect(p).resolves.toEqual({ online: ['a'] });
+  });
+
+  it('subscribePresence emits with peerIds payload', () => {
+    const fake = createFakeSocket();
+    const client = buildClient(fake);
+    client.subscribePresence(['a', 'b']);
+    expect(fake.emitted).toEqual([
+      { event: 'subscribe-presence', args: [{ peerIds: ['a', 'b'] }] },
+    ]);
+  });
+
+  it('sendSignal emits the SignalDto verbatim', () => {
+    const fake = createFakeSocket();
+    const client = buildClient(fake);
+    const signal: SignalDto = {
+      fromPeerId: 'a',
+      toPeerId: 'b',
+      payload: { type: 'offer', sdp: 'v=0' },
+    };
+    client.sendSignal(signal);
+    expect(fake.emitted).toEqual([{ event: 'signal', args: [signal] }]);
+  });
+
+  it('onSignal/offSignal subscribe and unsubscribe to "signal"', () => {
+    const fake = createFakeSocket();
+    const client = buildClient(fake);
+    const received: SignalDto[] = [];
+    const handler = (s: SignalDto): void => {
+      received.push(s);
+    };
+    client.onSignal(handler);
+    expect(fake.listeners.signal).toHaveLength(1);
+
+    const dispatch = (
+      fake.socket as unknown as { __dispatch: (e: string, p: SignalDto) => void }
+    ).__dispatch;
+    const dto: SignalDto = {
+      fromPeerId: 'a',
+      toPeerId: 'b',
+      payload: { type: 'answer', sdp: 'x' },
+    };
+    dispatch('signal', dto);
+    expect(received).toEqual([dto]);
+
+    client.offSignal(handler);
+    expect(fake.listeners.signal).toHaveLength(0);
+  });
+
+  it('onPresenceChange/offPresenceChange subscribe and unsubscribe', () => {
+    const fake = createFakeSocket();
+    const client = buildClient(fake);
+    const got: PresenceChangeDto[] = [];
+    const handler = (c: PresenceChangeDto): void => {
+      got.push(c);
+    };
+    client.onPresenceChange(handler);
+    expect(fake.listeners['presence-change']).toHaveLength(1);
+
+    const dispatch = (
+      fake.socket as unknown as {
+        __dispatch: (e: string, p: PresenceChangeDto) => void;
+      }
+    ).__dispatch;
+    dispatch('presence-change', { peerId: 'cam', online: true });
+    expect(got).toEqual([{ peerId: 'cam', online: true }]);
+
+    client.offPresenceChange(handler);
+    expect(fake.listeners['presence-change']).toHaveLength(0);
+  });
+});

--- a/apps/viewer/tests/unit/start-viewer-session.use-case.test.ts
+++ b/apps/viewer/tests/unit/start-viewer-session.use-case.test.ts
@@ -1,0 +1,335 @@
+import { StartViewerSessionUseCase } from '@/domain/use-cases/start-viewer-session.use-case';
+import type {
+  CameraConnection,
+  ConnectToCameraUseCase,
+} from '@/domain/use-cases/connect-to-camera.use-case';
+import type { ISignalingRepository } from '@/domain/repositories/i-signaling.repository';
+import { CameraBindingEntity } from '@/domain/entities/camera-binding.entity';
+import type { PresenceChangeDto } from '@sentinel-monitor/shared-types';
+
+interface FakeSignaling {
+  connected: boolean;
+  connectCalls: number;
+  registerCalls: string[];
+  subscribeCalls: Array<readonly string[]>;
+  queryCalls: Array<readonly string[]>;
+  presenceHandlers: Array<(c: PresenceChangeDto) => void>;
+  queryResult: { online: readonly string[] };
+  repo: ISignalingRepository;
+}
+
+function createFakeSignaling(initiallyConnected = false): FakeSignaling {
+  const f: FakeSignaling = {
+    connected: initiallyConnected,
+    connectCalls: 0,
+    registerCalls: [],
+    subscribeCalls: [],
+    queryCalls: [],
+    presenceHandlers: [],
+    queryResult: { online: [] },
+    repo: {} as ISignalingRepository,
+  };
+  f.repo = {
+    connect: async () => {
+      f.connectCalls += 1;
+      f.connected = true;
+    },
+    disconnect: () => {
+      f.connected = false;
+    },
+    isConnected: () => f.connected,
+    registerPresence: (id) => {
+      f.registerCalls.push(id);
+    },
+    redeemPairingCode: async () => ({
+      success: true,
+      data: { cameraId: 'c', dashboardId: 'd' },
+    }),
+    queryPresence: async (ids) => {
+      f.queryCalls.push(ids);
+      return f.queryResult;
+    },
+    subscribePresence: (ids) => {
+      f.subscribeCalls.push(ids);
+    },
+    sendSignal: () => undefined,
+    onSignal: () => undefined,
+    offSignal: () => undefined,
+    onPresenceChange: (h) => {
+      f.presenceHandlers.push(h);
+    },
+    offPresenceChange: (h) => {
+      f.presenceHandlers = f.presenceHandlers.filter((x) => x !== h);
+    },
+  };
+  return f;
+}
+
+interface RecordedConnect {
+  cameraId: string;
+  conn: CameraConnection;
+  closed: boolean;
+}
+
+function createConnectToCameraStub(): {
+  uc: ConnectToCameraUseCase;
+  records: RecordedConnect[];
+  failFor: Set<string>;
+} {
+  const records: RecordedConnect[] = [];
+  const failFor = new Set<string>();
+  const uc = {
+    async execute(cameraId: string): Promise<CameraConnection> {
+      if (failFor.has(cameraId)) {
+        throw new Error(`boom-${cameraId}`);
+      }
+      const rec: RecordedConnect = {
+        cameraId,
+        closed: false,
+        conn: {} as CameraConnection,
+      };
+      rec.conn = {
+        cameraId,
+        subscriber: {} as never,
+        close: () => {
+          rec.closed = true;
+        },
+      };
+      records.push(rec);
+      return rec.conn;
+    },
+  } as unknown as ConnectToCameraUseCase;
+  return { uc, records, failFor };
+}
+
+function makeBinding(cameraId: string, idx: number): CameraBindingEntity {
+  return CameraBindingEntity.create({
+    id: `binding-${idx}`,
+    cameraId,
+    label: `Camera ${idx}`,
+    addedAt: idx,
+  });
+}
+
+describe('StartViewerSessionUseCase', () => {
+  it('connects signaling when not yet connected and registers presence', async () => {
+    const signaling = createFakeSignaling(false);
+    const { uc: connectUC } = createConnectToCameraStub();
+    const useCase = new StartViewerSessionUseCase({
+      signaling: signaling.repo,
+      connectToCamera: connectUC,
+      dashboardId: 'dash-1',
+      onPresenceSnapshot: () => undefined,
+      onPresenceChange: () => undefined,
+    });
+    await useCase.execute({ bindings: [] });
+    expect(signaling.connectCalls).toBe(1);
+    expect(signaling.registerCalls).toEqual(['dash-1']);
+  });
+
+  it('skips connect when signaling is already connected', async () => {
+    const signaling = createFakeSignaling(true);
+    const { uc: connectUC } = createConnectToCameraStub();
+    const useCase = new StartViewerSessionUseCase({
+      signaling: signaling.repo,
+      connectToCamera: connectUC,
+      dashboardId: 'dash-1',
+      onPresenceSnapshot: () => undefined,
+      onPresenceChange: () => undefined,
+    });
+    await useCase.execute({ bindings: [] });
+    expect(signaling.connectCalls).toBe(0);
+  });
+
+  it('with no bindings, registers a noop presence handler that gets removed on stop', async () => {
+    const signaling = createFakeSignaling(true);
+    const { uc: connectUC } = createConnectToCameraStub();
+    const useCase = new StartViewerSessionUseCase({
+      signaling: signaling.repo,
+      connectToCamera: connectUC,
+      dashboardId: 'dash-1',
+      onPresenceSnapshot: () => undefined,
+      onPresenceChange: () => undefined,
+    });
+    const session = await useCase.execute({ bindings: [] });
+    expect(signaling.subscribeCalls).toHaveLength(0);
+    expect(signaling.queryCalls).toHaveLength(0);
+    expect(signaling.presenceHandlers).toHaveLength(1);
+    await session.stop();
+    expect(signaling.presenceHandlers).toHaveLength(0);
+  });
+
+  it('subscribes + queries presence and connects to every online camera', async () => {
+    const signaling = createFakeSignaling(true);
+    signaling.queryResult = { online: ['cam-A', 'cam-C'] };
+    const { uc: connectUC, records } = createConnectToCameraStub();
+    const snapshots: ReadonlyArray<readonly string[]> = [];
+    const useCase = new StartViewerSessionUseCase({
+      signaling: signaling.repo,
+      connectToCamera: connectUC,
+      dashboardId: 'dash-1',
+      onPresenceSnapshot: (online) => {
+        (snapshots as string[][]).push([...online]);
+      },
+      onPresenceChange: () => undefined,
+    });
+    const bindings = [
+      makeBinding('cam-A', 1),
+      makeBinding('cam-B', 2),
+      makeBinding('cam-C', 3),
+    ];
+    const session = await useCase.execute({ bindings });
+    expect(signaling.subscribeCalls).toEqual([['cam-A', 'cam-B', 'cam-C']]);
+    expect(signaling.queryCalls).toEqual([['cam-A', 'cam-B', 'cam-C']]);
+    expect(snapshots).toEqual([['cam-A', 'cam-C']]);
+    expect(records.map((r) => r.cameraId)).toEqual(['cam-A', 'cam-C']);
+    expect(session.connections.size).toBe(2);
+    expect(session.connections.has('cam-A')).toBe(true);
+    expect(session.connections.has('cam-C')).toBe(true);
+  });
+
+  it('survives a connect failure and continues with the remaining cameras', async () => {
+    const signaling = createFakeSignaling(true);
+    signaling.queryResult = { online: ['cam-A', 'cam-B'] };
+    const { uc: connectUC, records, failFor } = createConnectToCameraStub();
+    failFor.add('cam-A');
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const useCase = new StartViewerSessionUseCase({
+      signaling: signaling.repo,
+      connectToCamera: connectUC,
+      dashboardId: 'dash-1',
+      onPresenceSnapshot: () => undefined,
+      onPresenceChange: () => undefined,
+    });
+    const session = await useCase.execute({
+      bindings: [makeBinding('cam-A', 1), makeBinding('cam-B', 2)],
+    });
+    expect(records.map((r) => r.cameraId)).toEqual(['cam-B']);
+    expect(session.connections.has('cam-B')).toBe(true);
+    expect(session.connections.has('cam-A')).toBe(false);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('reacts to presence-change online by connecting and storing the connection', async () => {
+    const signaling = createFakeSignaling(true);
+    signaling.queryResult = { online: [] };
+    const { uc: connectUC, records } = createConnectToCameraStub();
+    const changes: Array<[string, boolean]> = [];
+    const useCase = new StartViewerSessionUseCase({
+      signaling: signaling.repo,
+      connectToCamera: connectUC,
+      dashboardId: 'dash-1',
+      onPresenceSnapshot: () => undefined,
+      onPresenceChange: (id, online) => changes.push([id, online]),
+    });
+    const session = await useCase.execute({
+      bindings: [makeBinding('cam-A', 1)],
+    });
+    const handler = signaling.presenceHandlers[0]!;
+    handler({ peerId: 'cam-A', online: true });
+    // wait for the dispatched .then() to resolve
+    await new Promise((r) => setTimeout(r, 0));
+    expect(changes).toEqual([['cam-A', true]]);
+    expect(records.map((r) => r.cameraId)).toEqual(['cam-A']);
+    expect(session.connections.has('cam-A')).toBe(true);
+  });
+
+  it('ignores presence changes for unknown peers', async () => {
+    const signaling = createFakeSignaling(true);
+    const { uc: connectUC, records } = createConnectToCameraStub();
+    const changes: Array<[string, boolean]> = [];
+    const useCase = new StartViewerSessionUseCase({
+      signaling: signaling.repo,
+      connectToCamera: connectUC,
+      dashboardId: 'dash-1',
+      onPresenceSnapshot: () => undefined,
+      onPresenceChange: (id, online) => changes.push([id, online]),
+    });
+    await useCase.execute({ bindings: [makeBinding('cam-A', 1)] });
+    signaling.presenceHandlers[0]!({ peerId: 'cam-OTHER', online: true });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(changes).toEqual([]);
+    expect(records).toHaveLength(0);
+  });
+
+  it('does not double-connect when an online change arrives for an already-connected peer', async () => {
+    const signaling = createFakeSignaling(true);
+    signaling.queryResult = { online: ['cam-A'] };
+    const { uc: connectUC, records } = createConnectToCameraStub();
+    const useCase = new StartViewerSessionUseCase({
+      signaling: signaling.repo,
+      connectToCamera: connectUC,
+      dashboardId: 'dash-1',
+      onPresenceSnapshot: () => undefined,
+      onPresenceChange: () => undefined,
+    });
+    await useCase.execute({ bindings: [makeBinding('cam-A', 1)] });
+    expect(records).toHaveLength(1);
+    signaling.presenceHandlers[0]!({ peerId: 'cam-A', online: true });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(records).toHaveLength(1);
+  });
+
+  it('closes and removes the connection when a peer goes offline', async () => {
+    const signaling = createFakeSignaling(true);
+    signaling.queryResult = { online: ['cam-A'] };
+    const { uc: connectUC, records } = createConnectToCameraStub();
+    const useCase = new StartViewerSessionUseCase({
+      signaling: signaling.repo,
+      connectToCamera: connectUC,
+      dashboardId: 'dash-1',
+      onPresenceSnapshot: () => undefined,
+      onPresenceChange: () => undefined,
+    });
+    const session = await useCase.execute({
+      bindings: [makeBinding('cam-A', 1)],
+    });
+    signaling.presenceHandlers[0]!({ peerId: 'cam-A', online: false });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(records[0]!.closed).toBe(true);
+    expect(session.connections.has('cam-A')).toBe(false);
+  });
+
+  it('logs a warning if reconnect fails', async () => {
+    const signaling = createFakeSignaling(true);
+    signaling.queryResult = { online: [] };
+    const { uc: connectUC, failFor } = createConnectToCameraStub();
+    failFor.add('cam-A');
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const useCase = new StartViewerSessionUseCase({
+      signaling: signaling.repo,
+      connectToCamera: connectUC,
+      dashboardId: 'dash-1',
+      onPresenceSnapshot: () => undefined,
+      onPresenceChange: () => undefined,
+    });
+    await useCase.execute({ bindings: [makeBinding('cam-A', 1)] });
+    signaling.presenceHandlers[0]!({ peerId: 'cam-A', online: true });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('stop() unsubscribes presence handler and closes every active connection', async () => {
+    const signaling = createFakeSignaling(true);
+    signaling.queryResult = { online: ['cam-A', 'cam-B'] };
+    const { uc: connectUC, records } = createConnectToCameraStub();
+    const useCase = new StartViewerSessionUseCase({
+      signaling: signaling.repo,
+      connectToCamera: connectUC,
+      dashboardId: 'dash-1',
+      onPresenceSnapshot: () => undefined,
+      onPresenceChange: () => undefined,
+    });
+    const session = await useCase.execute({
+      bindings: [makeBinding('cam-A', 1), makeBinding('cam-B', 2)],
+    });
+    await session.stop();
+    expect(signaling.presenceHandlers).toHaveLength(0);
+    expect(records.every((r) => r.closed)).toBe(true);
+    expect(session.connections.size).toBe(0);
+  });
+});

--- a/apps/viewer/tsconfig.json
+++ b/apps/viewer/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["ES2022", "DOM"],
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "types": ["jest"],
+    "types": ["jest", "node"],
     "allowSyntheticDefaultImports": true,
     "noEmit": true,
     "paths": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,7 +75,7 @@ importers:
         version: 4.8.3
       ts-jest:
         specifier: ^29.2.0
-        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0)(typescript@5.6.3)
+        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.39))(typescript@5.6.3)
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
@@ -94,6 +94,9 @@ importers:
       '@sentinel-monitor/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types
+      '@sentinel-monitor/webrtc-config':
+        specifier: workspace:^
+        version: link:../../packages/webrtc-config
       expo:
         specifier: ~52.0.0
         version: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
@@ -127,6 +130,9 @@ importers:
       react-native-web:
         specifier: ~0.19.13
         version: 0.19.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      socket.io-client:
+        specifier: ^4.8.0
+        version: 4.8.3
       zustand:
         specifier: ^5.0.0
         version: 5.0.12(@types/react@18.3.28)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
@@ -137,6 +143,9 @@ importers:
       '@types/jest':
         specifier: ^29.5.0
         version: 29.5.14
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
       '@types/react':
         specifier: ~18.3.12
         version: 18.3.28
@@ -154,7 +163,7 @@ importers:
         version: 29.7.0
       ts-jest:
         specifier: ^29.2.0
-        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0)(typescript@5.6.3)
+        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.39))(typescript@5.6.3)
       typescript:
         specifier: ~5.6.0
         version: 5.6.3
@@ -10714,7 +10723,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0)(typescript@5.6.3):
+  ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.39))(typescript@5.6.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0


### PR DESCRIPTION
## Summary

Wires the dashboard to live WebRTC against the camera publisher (web target).

- New domain ports: `ISignalingRepository`, `IWebRtcSubscriberRepository`.
- New use cases:
  - `ConnectToCameraUseCase` — single subscriber-driven handshake (offer + answer + ICE) routed through signaling, surfaces remote `MediaStream` + state.
  - `StartViewerSessionUseCase` — connects signaling, registers presence, queries + subscribes presence for bound cameras, eagerly connects to every online peer, and reacts to `presence-change` to open/close peer connections.
- New infrastructure: `SocketIoSignalingClient` (typed against shared event maps) and `BrowserWebRtcSubscriber` (RTCPeerConnection with `recvonly` transceivers). Native subscriber is a stub that throws — implementation lands in PR7 with `react-native-webrtc`.
- New presentation: `peers.store` (cameraId → stream + state) and `presence.store` (cameraId → online), both following the existing Zustand singleton pattern. `CameraTile` renders `VideoSurface` (web: `<video>`, native: stub) + presence dot.

Closes #6

## Acceptance criteria

- [x] On viewer boot: `registerPresence` + `queryPresence([bindingIds])` + `subscribePresence`.
- [x] For each online camera: `ConnectToCameraUseCase` creates `RTCPeerConnection`, `createOffer`, sends via signaling, handles answer + ICE.
- [x] On `presence-change{cameraId, online:true}` → trigger `ConnectToCamera`; on `online:false` → close peer (tile reflects `offline` via state).
- [x] `<CameraTile />` renders `<VideoSurface stream={...} />` + label + presence dot.
- [ ] Web E2E smoke (open camera in tab A, viewer in tab B, add code, video within 3s) — manual QA, not covered by this PR's automated tests.
- [x] Reload viewer → reconnects automatically (bindings re-hydrate from storage and `StartViewerSessionUseCase` re-runs the connect flow).
- [x] `pnpm --filter @sentinel-monitor/viewer test` ≥ 80% on `connect-to-camera`, `presence.store`, `peers.store`, `signaling.client` (achieved 95%+ on each).

## Coverage snapshot

| File | Stmts | Branch | Funcs | Lines |
|---|---|---|---|---|
| `connect-to-camera.use-case.ts` | 100% | 100% | 100% | 100% |
| `start-viewer-session.use-case.ts` | 97.7% | 100% | 88.8% | 100% |
| `socketio-signaling.client.ts` | 97.3% | 85.7% | 95.4% | 97.2% |
| `peers.store.ts` | 96.5% | 100% | 90% | 96.3% |
| `presence.store.ts` | 95.6% | 100% | 88.8% | 95% |

Globally: 90 tests pass (15 suites), aggregate coverage 97.8% statements / 96% branches.

## Test plan

- [x] `pnpm typecheck` (green across the workspace)
- [x] `pnpm --filter @sentinel-monitor/viewer test` (90/90 green)
- [x] `pnpm --filter @sentinel-monitor/viewer test:coverage` (every listed path > 80%)
- [ ] Manual web smoke: pair a camera, verify live video appears in the dashboard tile and survives a viewer reload.
- [ ] Manual presence flip: stop the camera process, watch the tile go offline; restart it, watch it auto-reconnect.

## Notes

Production code in this PR was authored in a prior session that was interrupted before tests, commit, and PR could be opened. This continuation added the unit tests for `connect-to-camera`, `start-viewer-session`, `socketio-signaling.client`, `peers.store`, and `presence.store`, extended `collectCoverageFrom` to include `src/infrastructure/signaling/**`, then committed and opened the PR. No production code was modified.