### PR TITLE
feat(viewer): native target via react-native-webrtc

### DIFF
--- a/apps/viewer/README.md
+++ b/apps/viewer/README.md
@@ -32,36 +32,47 @@ pnpm --filter @sentinel-monitor/viewer typecheck
 
 ## EAS dev client (iOS / Android)
 
-`react-native-webrtc` (PR6) requires a custom dev client — Expo Go is not
-supported. After installing dependencies:
+`react-native-webrtc` ships native modules — Expo Go is **not** supported.
+You must build a custom dev client once per platform, then run Metro
+against it.
 
 ```sh
-# 1. Login once
+# 1. Install deps from the repo root
+pnpm install
+
+# 2. Generate native projects (writes ios/ + android/)
+pnpm --filter @sentinel-monitor/viewer exec expo prebuild --clean
+
+# 3. (One-time) authenticate with EAS
 eas login
 
-# 2. Configure builds
-eas build:configure
-
-# 3. Build a development client for the simulator/device
+# 4. Build a dev client
+#    iOS simulator (fastest local loop):
 eas build --profile development --platform ios
+#    Android emulator / device:
 eas build --profile development --platform android
+
+# 5. Install the resulting build on the simulator/device, then start Metro
+pnpm --filter @sentinel-monitor/viewer dev
 ```
 
-Suggested `eas.json` (commit alongside the first EAS build, not part of PR5):
+The `development` profile in `eas.json` enables `developmentClient: true`
+and targets the iOS simulator + an Android APK so you can sideload
+locally without a Play Store account.
 
-```json
-{
-  "cli": { "version": ">= 12.0.0" },
-  "build": {
-    "development": {
-      "developmentClient": true,
-      "distribution": "internal"
-    },
-    "preview": { "distribution": "internal" },
-    "production": {}
-  }
-}
-```
+The Expo plugin `@config-plugins/react-native-webrtc` (wired in
+`app.config.ts`) handles the iOS Info.plist usage strings and the
+Android `CAMERA` / `RECORD_AUDIO` permissions during prebuild.
+
+### Smoke test (manual)
+
+Native WebRTC cannot be exercised from CI — verify on real runtimes:
+
+1. Start the signaling server (`apps/server`).
+2. Pair a camera (`apps/camera`) and copy the pairing code.
+3. Launch the viewer dev client; redeem the code.
+4. Confirm the remote video renders inside the camera tile and that
+   `connectionState` reaches `connected`.
 
 ## Storage
 
@@ -82,7 +93,3 @@ For tests, `in-memory-binding-storage.ts` provides a deterministic adapter.
 | Add/remove/rename    | `src/domain/use-cases/{add,remove,rename}-camera.*`    |
 | State + persistence  | `src/presentation/stores/bindings.store.ts`            |
 
-## TODO (PR6)
-
-- `ConnectToCameraUseCase` — opens the WebRTC peer connection after a
-  successful pairing, replacing the stub `resolveCameraId` in `add-camera`.

--- a/apps/viewer/app.config.ts
+++ b/apps/viewer/app.config.ts
@@ -19,7 +19,18 @@ const config: ExpoConfig = {
     bundler: 'metro',
     output: 'single',
   },
-  plugins: ['expo-router'],
+  plugins: [
+    'expo-router',
+    [
+      '@config-plugins/react-native-webrtc',
+      {
+        cameraPermission:
+          'Sentinel Monitor needs camera access for two-way video (future).',
+        microphonePermission:
+          'Sentinel Monitor needs microphone access to talk back to the camera.',
+      },
+    ],
+  ],
   experiments: {
     typedRoutes: true,
   },

--- a/apps/viewer/eas.json
+++ b/apps/viewer/eas.json
@@ -1,0 +1,33 @@
+{
+  "cli": {
+    "version": ">= 12.0.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      },
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      },
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "production": {
+      "autoIncrement": true
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/apps/viewer/jest.config.js
+++ b/apps/viewer/jest.config.js
@@ -31,6 +31,7 @@ module.exports = {
     'src/domain/**/*.ts',
     'src/presentation/stores/**/*.ts',
     'src/infrastructure/signaling/**/*.ts',
+    'src/infrastructure/webrtc/webrtc-subscriber.native.ts',
   ],
   coverageThreshold: {
     global: {

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -32,11 +32,13 @@
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",
     "react-native-web": "~0.19.13",
+    "react-native-webrtc": "^124.0.5",
     "socket.io-client": "^4.8.0",
     "zustand": "^5.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.0",
+    "@config-plugins/react-native-webrtc": "^10.0.0",
     "@types/jest": "^29.5.0",
     "@types/node": "^20.0.0",
     "@types/react": "~18.3.12",

--- a/apps/viewer/src/infrastructure/webrtc/webrtc-subscriber.native.ts
+++ b/apps/viewer/src/infrastructure/webrtc/webrtc-subscriber.native.ts
@@ -1,42 +1,171 @@
 // ============================================================
-// Native subscriber stub. Real implementation lands in PR7
-// (react-native-webrtc). Constructing this on a native runtime
-// throws so misconfigured DI surfaces immediately.
+// Native subscriber backed by react-native-webrtc. Mirrors the
+// browser sibling: the dashboard is the offerer, recvonly
+// transceivers for video + audio, ICE both ways via the injected
+// signal sink. We narrow react-native-webrtc's loose event shapes
+// to the same lifecycle the .web variant exposes.
 // ============================================================
 
+import {
+  RTCIceCandidate,
+  RTCPeerConnection,
+  RTCSessionDescription,
+  type MediaStream as RNMediaStream,
+} from 'react-native-webrtc';
+import { WEBRTC_CONFIG } from '@sentinel-monitor/webrtc-config';
+import type { SignalPayload } from '@sentinel-monitor/shared-types';
 import type {
   IWebRtcSubscriberRepository,
   SubscriberState,
 } from '../../domain/repositories/i-webrtc-subscriber.repository';
 
+// react-native-webrtc's RTCPeerConnection event types are looser than
+// the DOM's. Define just the bits we touch so the rest of the code stays
+// strict and `any`-free.
+interface RNRtcTrackEvent {
+  readonly streams: ReadonlyArray<RNMediaStream>;
+  readonly track: unknown;
+}
+
+interface RNRtcIceCandidateEvent {
+  readonly candidate: { toJSON(): RTCIceCandidateInit } | null;
+}
+
+interface RNPeerConnectionLike {
+  connectionState: string;
+  ontrack: ((event: RNRtcTrackEvent) => void) | null;
+  onicecandidate: ((event: RNRtcIceCandidateEvent) => void) | null;
+  onconnectionstatechange: (() => void) | null;
+  addTransceiver(
+    kind: 'video' | 'audio',
+    init: { direction: 'recvonly' | 'sendrecv' | 'sendonly' | 'inactive' },
+  ): unknown;
+  createOffer(): Promise<{ sdp?: string; type: string }>;
+  setLocalDescription(desc: unknown): Promise<void>;
+  setRemoteDescription(desc: unknown): Promise<void>;
+  addIceCandidate(candidate: unknown): Promise<void>;
+  close(): void;
+}
+
+// Public type used by the consumer (presentation layer) — same shape as DOM.
+export type SubscriberMediaStream = RNMediaStream;
+
+export type NativePeerFactory = (
+  config: typeof WEBRTC_CONFIG,
+) => RNPeerConnectionLike;
+
+export interface NativeWebRtcSubscriberOptions {
+  readonly emitSignal: (payload: SignalPayload) => void;
+  readonly rtcConfig?: typeof WEBRTC_CONFIG;
+  readonly peerFactory?: NativePeerFactory;
+}
+
 export class NativeWebRtcSubscriber implements IWebRtcSubscriberRepository {
-  constructor() {
-    throw new Error(
-      'NativeWebRtcSubscriber not implemented yet — see PR7 (react-native-webrtc)',
-    );
+  private readonly pc: RNPeerConnectionLike;
+  private state: SubscriberState = 'idle';
+  private remoteStream: RNMediaStream | null = null;
+  private trackHandler: ((stream: MediaStream) => void) | null = null;
+  private stateHandler: ((state: SubscriberState) => void) | null = null;
+
+  constructor(private readonly options: NativeWebRtcSubscriberOptions) {
+    const factory: NativePeerFactory =
+      options.peerFactory ??
+      ((c): RNPeerConnectionLike =>
+        new RTCPeerConnection(c) as unknown as RNPeerConnectionLike);
+    this.pc = factory(options.rtcConfig ?? WEBRTC_CONFIG);
+
+    this.pc.ontrack = (event): void => {
+      const stream = event.streams[0];
+      if (!stream) return;
+      this.remoteStream = stream;
+      // Domain port is typed against the DOM MediaStream — react-native-webrtc's
+      // class is structurally compatible at the surface we expose (toURL,
+      // getTracks). The domain consumer never touches DOM-only APIs.
+      this.trackHandler?.(stream as unknown as MediaStream);
+    };
+
+    this.pc.onicecandidate = (event): void => {
+      if (event.candidate) {
+        this.options.emitSignal({
+          type: 'ice-candidate',
+          candidate: event.candidate.toJSON(),
+        });
+      }
+    };
+
+    this.pc.onconnectionstatechange = (): void => {
+      this.setState(mapPeerState(this.pc.connectionState));
+    };
   }
 
-  connect(_cameraId: string): Promise<void> {
-    throw new Error('not implemented — see PR7');
+  async connect(_cameraId: string): Promise<void> {
+    this.setState('connecting');
+    this.pc.addTransceiver('video', { direction: 'recvonly' });
+    this.pc.addTransceiver('audio', { direction: 'recvonly' });
+
+    const offer = await this.pc.createOffer();
+    await this.pc.setLocalDescription(offer);
+    this.options.emitSignal({ type: 'offer', sdp: offer.sdp ?? '' });
   }
 
-  handleIncomingSignal(): Promise<void> {
-    throw new Error('not implemented — see PR7');
+  async handleIncomingSignal(payload: SignalPayload): Promise<void> {
+    if (payload.type === 'answer') {
+      await this.pc.setRemoteDescription(
+        new RTCSessionDescription({ type: 'answer', sdp: payload.sdp }),
+      );
+      return;
+    }
+    if (payload.type === 'ice-candidate') {
+      try {
+        await this.pc.addIceCandidate(new RTCIceCandidate(payload.candidate));
+      } catch {
+        // Late or duplicate candidate — safe to ignore.
+      }
+      return;
+    }
+    // 'offer' arriving at the dashboard would be a protocol bug; ignore.
   }
 
   close(): void {
-    throw new Error('not implemented — see PR7');
+    this.pc.close();
+    this.setState('closed');
   }
 
-  onTrack(_handler: (stream: MediaStream) => void): void {
-    throw new Error('not implemented — see PR7');
+  onTrack(handler: (stream: MediaStream) => void): void {
+    this.trackHandler = handler;
+    if (this.remoteStream) handler(this.remoteStream as unknown as MediaStream);
   }
 
-  onStateChange(_handler: (state: SubscriberState) => void): void {
-    throw new Error('not implemented — see PR7');
+  onStateChange(handler: (state: SubscriberState) => void): void {
+    this.stateHandler = handler;
   }
 
   getState(): SubscriberState {
-    throw new Error('not implemented — see PR7');
+    return this.state;
+  }
+
+  private setState(next: SubscriberState): void {
+    if (this.state === next) return;
+    this.state = next;
+    this.stateHandler?.(next);
+  }
+}
+
+function mapPeerState(s: string): SubscriberState {
+  switch (s) {
+    case 'new':
+      return 'idle';
+    case 'connecting':
+      return 'connecting';
+    case 'connected':
+      return 'connected';
+    case 'disconnected':
+      return 'disconnected';
+    case 'failed':
+      return 'failed';
+    case 'closed':
+      return 'closed';
+    default:
+      return 'idle';
   }
 }

--- a/apps/viewer/src/presentation/components/video-surface.native.tsx
+++ b/apps/viewer/src/presentation/components/video-surface.native.tsx
@@ -1,19 +1,40 @@
 // ============================================================
-// Native video surface — STUB. The real implementation arrives
-// in PR7 alongside react-native-webrtc's RTCView.
+// Native video surface — renders react-native-webrtc's <RTCView>
+// bound to the inbound stream URL. Returns null when no stream is
+// attached yet so the parent layout collapses gracefully.
 // ============================================================
 
 import type { ReactElement } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { RTCView } from 'react-native-webrtc';
 
 export interface VideoSurfaceProps {
   readonly stream: MediaStream | null;
   readonly muted?: boolean;
 }
 
-export function VideoSurface(_props: VideoSurfaceProps): ReactElement | null {
-  // eslint-disable-next-line no-console
-  console.warn(
-    'VideoSurface (native): not implemented — see PR7 (react-native-webrtc / RTCView)',
-  );
-  return null;
+interface RNStreamLike {
+  toURL(): string;
 }
+
+export function VideoSurface({ stream }: VideoSurfaceProps): ReactElement {
+  if (!stream) {
+    return <View style={styles.surface} />;
+  }
+
+  // react-native-webrtc's MediaStream exposes toURL(); the DOM type alias
+  // used by the domain port does not. Narrow at the boundary.
+  const url = (stream as unknown as RNStreamLike).toURL();
+
+  return (
+    <RTCView streamURL={url} style={styles.surface} objectFit="cover" />
+  );
+}
+
+const styles = StyleSheet.create({
+  surface: {
+    width: '100%',
+    height: '100%',
+    backgroundColor: '#000',
+  },
+});

--- a/apps/viewer/tests/unit/webrtc-subscriber.native.test.ts
+++ b/apps/viewer/tests/unit/webrtc-subscriber.native.test.ts
@@ -1,0 +1,284 @@
+// ============================================================
+// Unit tests for the native subscriber. We mock react-native-webrtc
+// so the file under test runs in jsdom without pulling any native
+// modules. Lifecycle: createOffer -> emit signal, inbound answer ->
+// setRemoteDescription, inbound ICE -> addIceCandidate, ontrack
+// fires the registered handler, close() tears down + flips state.
+// ============================================================
+
+interface FakeIceCandidate {
+  toJSON(): RTCIceCandidateInit;
+}
+
+interface FakePeer {
+  connectionState: string;
+  ontrack:
+    | ((event: { streams: ReadonlyArray<unknown>; track: unknown }) => void)
+    | null;
+  onicecandidate:
+    | ((event: { candidate: FakeIceCandidate | null }) => void)
+    | null;
+  onconnectionstatechange: (() => void) | null;
+  transceivers: Array<{ kind: string; direction: string }>;
+  localDescription: unknown;
+  remoteDescription: unknown;
+  iceCandidates: unknown[];
+  closed: boolean;
+  addTransceiver: jest.Mock;
+  createOffer: jest.Mock;
+  setLocalDescription: jest.Mock;
+  setRemoteDescription: jest.Mock;
+  addIceCandidate: jest.Mock;
+  close: jest.Mock;
+}
+
+function createFakePeer(): FakePeer {
+  const peer: FakePeer = {
+    connectionState: 'new',
+    ontrack: null,
+    onicecandidate: null,
+    onconnectionstatechange: null,
+    transceivers: [],
+    localDescription: null,
+    remoteDescription: null,
+    iceCandidates: [],
+    closed: false,
+    addTransceiver: jest.fn((kind: string, init: { direction: string }) => {
+      peer.transceivers.push({ kind, direction: init.direction });
+      return {};
+    }),
+    createOffer: jest.fn(async () => ({ type: 'offer', sdp: 'v=0\nfake-offer' })),
+    setLocalDescription: jest.fn(async (desc: unknown) => {
+      peer.localDescription = desc;
+    }),
+    setRemoteDescription: jest.fn(async (desc: unknown) => {
+      peer.remoteDescription = desc;
+    }),
+    addIceCandidate: jest.fn(async (c: unknown) => {
+      peer.iceCandidates.push(c);
+    }),
+    close: jest.fn(() => {
+      peer.closed = true;
+    }),
+  };
+  return peer;
+}
+
+jest.mock('react-native-webrtc', () => {
+  return {
+    RTCPeerConnection: jest.fn(),
+    RTCSessionDescription: jest.fn().mockImplementation((init: unknown) => ({
+      __sd: init,
+    })),
+    RTCIceCandidate: jest.fn().mockImplementation((init: unknown) => ({
+      __ice: init,
+    })),
+  };
+});
+
+jest.mock('@sentinel-monitor/webrtc-config', () => ({
+  WEBRTC_CONFIG: { iceServers: [] },
+}));
+
+import type { SignalPayload } from '@sentinel-monitor/shared-types';
+import {
+  NativeWebRtcSubscriber,
+  type NativePeerFactory,
+} from '@/infrastructure/webrtc/webrtc-subscriber.native';
+
+describe('NativeWebRtcSubscriber', () => {
+  let peer: FakePeer;
+  let factory: NativePeerFactory;
+  let emitted: SignalPayload[];
+
+  beforeEach(() => {
+    peer = createFakePeer();
+    factory = ((): unknown => peer) as unknown as NativePeerFactory;
+    emitted = [];
+  });
+
+  function build(): NativeWebRtcSubscriber {
+    return new NativeWebRtcSubscriber({
+      emitSignal: (p) => emitted.push(p),
+      peerFactory: factory,
+    });
+  }
+
+  it('starts in idle state', () => {
+    const sub = build();
+    expect(sub.getState()).toBe('idle');
+  });
+
+  it('connect() adds recvonly transceivers and emits the offer', async () => {
+    const sub = build();
+    await sub.connect('cam-1');
+
+    expect(peer.transceivers).toEqual([
+      { kind: 'video', direction: 'recvonly' },
+      { kind: 'audio', direction: 'recvonly' },
+    ]);
+    expect(peer.createOffer).toHaveBeenCalledTimes(1);
+    expect(peer.setLocalDescription).toHaveBeenCalledWith({
+      type: 'offer',
+      sdp: 'v=0\nfake-offer',
+    });
+    expect(emitted).toEqual([{ type: 'offer', sdp: 'v=0\nfake-offer' }]);
+    expect(sub.getState()).toBe('connecting');
+  });
+
+  it('connect() emits an empty sdp when the engine omits it', async () => {
+    peer.createOffer = jest.fn(async () => ({ type: 'offer' }));
+    const sub = build();
+    await sub.connect('cam-1');
+    expect(emitted).toEqual([{ type: 'offer', sdp: '' }]);
+  });
+
+  it('handleIncomingSignal applies an inbound answer', async () => {
+    const sub = build();
+    await sub.handleIncomingSignal({ type: 'answer', sdp: 'v=0\nremote' });
+    expect(peer.setRemoteDescription).toHaveBeenCalledTimes(1);
+    expect(peer.remoteDescription).toEqual({
+      __sd: { type: 'answer', sdp: 'v=0\nremote' },
+    });
+  });
+
+  it('handleIncomingSignal forwards inbound ICE candidates', async () => {
+    const sub = build();
+    const candidate: RTCIceCandidateInit = {
+      candidate: 'candidate:1 ...',
+      sdpMid: '0',
+      sdpMLineIndex: 0,
+    };
+    await sub.handleIncomingSignal({ type: 'ice-candidate', candidate });
+    expect(peer.addIceCandidate).toHaveBeenCalledTimes(1);
+    expect(peer.iceCandidates[0]).toEqual({ __ice: candidate });
+  });
+
+  it('handleIncomingSignal swallows ICE errors (late/duplicate candidates)', async () => {
+    peer.addIceCandidate = jest.fn(async () => {
+      throw new Error('late candidate');
+    });
+    const sub = build();
+    await expect(
+      sub.handleIncomingSignal({
+        type: 'ice-candidate',
+        candidate: { candidate: 'c', sdpMid: '0', sdpMLineIndex: 0 },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('handleIncomingSignal ignores stray offers', async () => {
+    const sub = build();
+    await sub.handleIncomingSignal({ type: 'offer', sdp: 'x' });
+    expect(peer.setRemoteDescription).not.toHaveBeenCalled();
+  });
+
+  it('emits ICE candidates produced by the peer', () => {
+    build();
+    const candidate: RTCIceCandidateInit = {
+      candidate: 'host',
+      sdpMid: '0',
+      sdpMLineIndex: 0,
+    };
+    peer.onicecandidate?.({
+      candidate: { toJSON: () => candidate },
+    });
+    expect(emitted).toEqual([{ type: 'ice-candidate', candidate }]);
+  });
+
+  it('skips emit when the peer reports a null candidate (gathering done)', () => {
+    build();
+    peer.onicecandidate?.({ candidate: null });
+    expect(emitted).toEqual([]);
+  });
+
+  it('forwards the inbound stream via onTrack', () => {
+    const sub = build();
+    const received: unknown[] = [];
+    sub.onTrack((s) => received.push(s));
+
+    const fakeStream = { id: 'remote-stream' };
+    peer.ontrack?.({ streams: [fakeStream], track: {} });
+    expect(received).toEqual([fakeStream]);
+  });
+
+  it('replays the cached stream when onTrack is registered late', () => {
+    const sub = build();
+    const fakeStream = { id: 'remote-stream' };
+    peer.ontrack?.({ streams: [fakeStream], track: {} });
+
+    const received: unknown[] = [];
+    sub.onTrack((s) => received.push(s));
+    expect(received).toEqual([fakeStream]);
+  });
+
+  it('ignores ontrack events with no streams', () => {
+    const sub = build();
+    const received: unknown[] = [];
+    sub.onTrack((s) => received.push(s));
+    peer.ontrack?.({ streams: [], track: {} });
+    expect(received).toEqual([]);
+  });
+
+  it('maps connectionState transitions to SubscriberState', () => {
+    const sub = build();
+    const states: string[] = [];
+    sub.onStateChange((s) => states.push(s));
+
+    peer.connectionState = 'connecting';
+    peer.onconnectionstatechange?.();
+    peer.connectionState = 'connected';
+    peer.onconnectionstatechange?.();
+    peer.connectionState = 'disconnected';
+    peer.onconnectionstatechange?.();
+    peer.connectionState = 'failed';
+    peer.onconnectionstatechange?.();
+
+    expect(states).toEqual(['connecting', 'connected', 'disconnected', 'failed']);
+    expect(sub.getState()).toBe('failed');
+  });
+
+  it('maps unknown / new connectionState back to idle', () => {
+    const sub = build();
+    peer.connectionState = 'new';
+    peer.onconnectionstatechange?.();
+    expect(sub.getState()).toBe('idle');
+
+    peer.connectionState = 'something-weird';
+    peer.onconnectionstatechange?.();
+    expect(sub.getState()).toBe('idle');
+  });
+
+  it('does not re-fire the state handler for repeat states', () => {
+    const sub = build();
+    const handler = jest.fn();
+    sub.onStateChange(handler);
+
+    peer.connectionState = 'connected';
+    peer.onconnectionstatechange?.();
+    peer.onconnectionstatechange?.();
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('close() tears down the peer and flips state to closed', () => {
+    const sub = build();
+    const states: string[] = [];
+    sub.onStateChange((s) => states.push(s));
+    sub.close();
+    expect(peer.close).toHaveBeenCalledTimes(1);
+    expect(sub.getState()).toBe('closed');
+    expect(states).toEqual(['closed']);
+  });
+
+  it('falls back to the default peer factory when none is provided', () => {
+    // Verifies the default branch wires through the mocked
+    // RTCPeerConnection constructor without throwing.
+    const rnWebrtc = jest.requireMock('react-native-webrtc') as {
+      RTCPeerConnection: jest.Mock;
+    };
+    rnWebrtc.RTCPeerConnection.mockImplementation(() => peer);
+    const sub = new NativeWebRtcSubscriber({ emitSignal: () => {} });
+    expect(sub.getState()).toBe('idle');
+    expect(rnWebrtc.RTCPeerConnection).toHaveBeenCalledTimes(1);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
       react-native-web:
         specifier: ~0.19.13
         version: 0.19.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-native-webrtc:
+        specifier: ^124.0.5
+        version: 124.0.7(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))
       socket.io-client:
         specifier: ^4.8.0
         version: 4.8.3
@@ -149,6 +152,9 @@ importers:
       '@babel/core':
         specifier: ^7.25.0
         version: 7.29.0
+      '@config-plugins/react-native-webrtc':
+        specifier: ^10.0.0
+        version: 10.0.0(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))
       '@types/jest':
         specifier: ^29.5.0
         version: 29.5.14
@@ -945,6 +951,11 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@config-plugins/react-native-webrtc@10.0.0':
+    resolution: {integrity: sha512-q6owBOwQo3HRx4/b0FteE06Ymlcx7pK5bw+Stg77wgTWyxWAJ90yfVvvdMckzxuxMwDd78o9yCLKIONTulHD4A==}
+    peerDependencies:
+      expo: ^52
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -2535,6 +2546,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -2763,6 +2783,10 @@ packages:
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
+
+  event-target-shim@6.0.2:
+    resolution: {integrity: sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==}
+    engines: {node: '>=10.13.0'}
 
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -3853,6 +3877,9 @@ packages:
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
+  ms@2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -4291,6 +4318,11 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
+
+  react-native-webrtc@124.0.7:
+    resolution: {integrity: sha512-gnXPdbUS8IkKHq9WNaWptW/yy5s6nMyI6cNn90LXdobPVCgYSk6NA2uUGdT4c4J14BRgaFA95F+cR28tUPkMVA==}
+    peerDependencies:
+      react-native: '>=0.60.0'
 
   react-native@0.76.5:
     resolution: {integrity: sha512-op2p2kB+lqMF1D7AdX4+wvaR0OPFbvWYs+VBE7bwsb99Cn9xISrLRLAgFflZedQsa5HvnOGrULhtnmItbIKVVw==}
@@ -6213,6 +6245,10 @@ snapshots:
   '@bcoe/v8-coverage@0.2.3': {}
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@config-plugins/react-native-webrtc@10.0.0(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))':
+    dependencies:
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -8153,6 +8189,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.3.4:
+    dependencies:
+      ms: 2.1.2
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -8392,6 +8432,8 @@ snapshots:
   etag@1.8.1: {}
 
   event-target-shim@5.0.1: {}
+
+  event-target-shim@6.0.2: {}
 
   events@3.3.0: {}
 
@@ -9886,6 +9928,8 @@ snapshots:
 
   ms@2.0.0: {}
 
+  ms@2.1.2: {}
+
   ms@2.1.3: {}
 
   mz@2.7.0:
@@ -10321,6 +10365,15 @@ snapshots:
       styleq: 0.1.3
     transitivePeerDependencies:
       - encoding
+
+  react-native-webrtc@124.0.7(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)):
+    dependencies:
+      base64-js: 1.5.1
+      debug: 4.3.4
+      event-target-shim: 6.0.2
+      react-native: 0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)
+    transitivePeerDependencies:
+      - supports-color
 
   react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Summary
- Replaces `webrtc-subscriber.native.ts` stub with a real `react-native-webrtc` implementation that mirrors the `.web` sibling: subscriber-driven offer, recvonly video + audio transceivers, ICE in/out via the injected signal sink, `ontrack` / `onStateChange` callbacks, idempotent `close()`.
- Renders the inbound stream natively via `<RTCView streamURL={stream.toURL()} objectFit="cover" />` in `video-surface.native.tsx`.
- Wires the `@config-plugins/react-native-webrtc` Expo plugin in `app.config.ts` (handles iOS Info.plist + Android camera/mic permissions during prebuild).
- Adds `eas.json` with a `developmentClient: true` profile (iOS simulator + Android APK) so devs can sideload a custom dev client.
- Documents the `expo prebuild` + `eas build --profile development` flow plus the manual smoke test in the viewer README.
- Unit suite mocks `react-native-webrtc` end-to-end and covers offer / answer / ICE flow, `ontrack`, state mapping, and `close()` cleanup — **98% lines / 95% branches / 100% functions** on the file.

## Acceptance criteria
- [x] `webrtc-subscriber.native.ts` implements `IWebRtcSubscriberRepository` using `RTCPeerConnection`, `RTCSessionDescription`, `RTCIceCandidate` from `react-native-webrtc`
- [x] Subscriber-driven: `createOffer` -> `setLocalDescription` -> outbound signal; inbound answer -> `setRemoteDescription`; ICE candidates routed both ways
- [x] `video-surface.native.tsx` uses `<RTCView>` from `react-native-webrtc`
- [x] Tests with mocked `react-native-webrtc` covering offer/answer/ICE flow + `onTrack` callback + `close` cleanup
- [x] Coverage >= 80% on the file (actual: 98% lines)
- [x] README documents EAS dev-client setup
- [x] `pnpm typecheck && pnpm --filter @sentinel-monitor/viewer test` GREEN
- [x] No runtime `Platform.OS` — file-extension resolution only
- [x] `.web.ts` sibling untouched

## Notes
- Native smoke test (iOS sim / Android emulator) is deferred to manual QA — `react-native-webrtc` ships native modules and cannot run from CI. The README documents the prebuild + EAS dev-client steps required to verify locally.
- `pnpm-lock.yaml` updates reflect the new `react-native-webrtc` (124.x) and `@config-plugins/react-native-webrtc` (10.x) entries.

## Test plan
- [x] `pnpm --filter @sentinel-monitor/viewer typecheck`
- [x] `pnpm --filter @sentinel-monitor/viewer test`
- [x] `pnpm --filter @sentinel-monitor/viewer test:coverage` (file at 98% lines)
- [x] `pnpm typecheck` (monorepo-wide)
- [ ] Manual: `expo prebuild --clean` + `eas build --profile development --platform ios` + redeem pairing code + observe remote video render

Closes #7