### PR TITLE
feat(viewer): grid polish — fullscreen, mute, presence dots, transitions

### DIFF
--- a/apps/viewer/app/camera/[id].tsx
+++ b/apps/viewer/app/camera/[id].tsx
@@ -1,38 +1,87 @@
-import { StyleSheet, Text, View } from 'react-native';
-import { useLocalSearchParams } from 'expo-router';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { VideoSurface } from '@/presentation/components/video-surface';
 import { useBindingsStore } from '@/presentation/stores/bindings.store';
-import { semantic, spacing, typography } from '@/presentation/theme';
+import { usePeersStore } from '@/presentation/stores/peers.store';
+import { radii, semantic, spacing, typography } from '@/presentation/theme';
 
 export default function CameraFullscreen(): JSX.Element {
+  const router = useRouter();
   const params = useLocalSearchParams<{ id: string }>();
   const id = typeof params.id === 'string' ? params.id : '';
   const binding = useBindingsStore((s) => s.bindings.find((b) => b.id === id));
+  const peer = usePeersStore((s) => s.peers[id]);
+
+  const stream = peer?.stream ?? null;
+  const hasVideo = stream !== null;
 
   return (
     <View style={styles.root}>
-      <Text style={styles.label}>{binding?.label ?? 'Câmera'}</Text>
-      <View style={styles.placeholder}>
-        <Text style={styles.placeholderText}>
-          Vídeo em tempo real chegará no PR6.
-        </Text>
+      <View style={styles.surface}>
+        {hasVideo ? (
+          <View style={StyleSheet.absoluteFill}>
+            {/* Fullscreen route: audio is unmuted by default. */}
+            <VideoSurface stream={stream} muted={false} />
+          </View>
+        ) : (
+          <Text style={styles.placeholderText}>
+            Sem vídeo no momento. Verifique a conexão da câmera.
+          </Text>
+        )}
+        <View style={styles.headerOverlay}>
+          <TouchableOpacity
+            onPress={() => router.back()}
+            hitSlop={12}
+            style={styles.backButton}
+            accessibilityRole="button"
+            accessibilityLabel="back-to-grid"
+          >
+            <Text style={styles.backText}>{'<'}</Text>
+          </TouchableOpacity>
+          <Text style={styles.label} numberOfLines={1}>
+            {binding?.label ?? 'Câmera'}
+          </Text>
+        </View>
       </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  root: { flex: 1, backgroundColor: semantic.bg.primary, padding: spacing[4] },
+  root: { flex: 1, backgroundColor: '#000' },
+  surface: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  placeholderText: {
+    color: semantic.text.muted,
+    fontSize: typography.size.sm,
+    paddingHorizontal: spacing[4],
+    textAlign: 'center',
+  },
+  headerOverlay: {
+    position: 'absolute',
+    top: spacing[4],
+    left: spacing[4],
+    right: spacing[4],
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+  },
+  backButton: {
+    width: 36,
+    height: 36,
+    borderRadius: radii.full,
+    backgroundColor: 'rgba(0,0,0,0.55)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  backText: {
+    color: semantic.text.primary,
+    fontSize: typography.size.lg,
+    fontWeight: typography.weight.bold,
+  },
   label: {
     color: semantic.text.primary,
     fontSize: typography.size.lg,
     fontWeight: typography.weight.semibold,
-    marginBottom: spacing[3],
-  },
-  placeholder: {
     flex: 1,
-    backgroundColor: semantic.bg.surface,
-    justifyContent: 'center',
-    alignItems: 'center',
   },
-  placeholderText: { color: semantic.text.muted, fontSize: typography.size.sm },
 });

--- a/apps/viewer/app/index.tsx
+++ b/apps/viewer/app/index.tsx
@@ -2,11 +2,15 @@ import { useMemo, useState } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import { ComputeGridLayoutUseCase } from '@/domain/use-cases/compute-grid-layout.use-case';
+import { ToggleCameraMuteUseCase } from '@/domain/use-cases/toggle-camera-mute.use-case';
 import { AddCameraModal } from '@/presentation/components/add-camera-modal';
 import { CameraTile } from '@/presentation/components/camera-tile.component';
 import { EmptyState } from '@/presentation/components/empty-state';
 import { useBindingsStore } from '@/presentation/stores/bindings.store';
-import { usePeersStore } from '@/presentation/stores/peers.store';
+import {
+  getPeersStoreSingleton,
+  usePeersStore,
+} from '@/presentation/stores/peers.store';
 import { usePresenceStore } from '@/presentation/stores/presence.store';
 import { radii, semantic, spacing, typography } from '@/presentation/theme';
 
@@ -17,7 +21,18 @@ export default function GridScreen(): JSX.Element {
   const bindings = useBindingsStore((s) => s.bindings);
   const addCamera = useBindingsStore((s) => s.addCamera);
   const removeCamera = useBindingsStore((s) => s.removeCamera);
+  const peers = usePeersStore((s) => s.peers);
+  const mutes = usePeersStore((s) => s.mutes);
+  const online = usePresenceStore((s) => s.online);
   const [modalOpen, setModalOpen] = useState<boolean>(false);
+
+  const toggleMuteUC = useMemo(
+    () =>
+      new ToggleCameraMuteUseCase({
+        store: getPeersStoreSingleton().getState(),
+      }),
+    [],
+  );
 
   const layout = useMemo(() => layoutUC.execute(bindings.length), [bindings]);
 
@@ -46,16 +61,28 @@ export default function GridScreen(): JSX.Element {
       <View style={styles.grid}>
         {rows.map((row, rowIdx) => (
           <View key={`row-${rowIdx}`} style={styles.row}>
-            {row.map((b) => (
-              <CameraTile
-                key={b.id}
-                binding={b}
-                onPress={() => router.push(`/camera/${b.id}`)}
-                onLongPress={() => {
-                  void removeCamera(b.id);
-                }}
-              />
-            ))}
+            {row.map((b) => {
+              const peer = peers[b.id];
+              const presenceKnown = b.id in online;
+              const isOnline = presenceKnown ? online[b.id] : undefined;
+              return (
+                <CameraTile
+                  key={b.id}
+                  binding={b}
+                  stream={peer?.stream ?? null}
+                  state={peer?.state}
+                  online={isOnline}
+                  muted={mutes[b.id] ?? false}
+                  onPress={() => router.push(`/camera/${b.id}`)}
+                  onLongPress={() => {
+                    void removeCamera(b.id);
+                  }}
+                  onToggleMute={() => {
+                    toggleMuteUC.execute(b.id);
+                  }}
+                />
+              );
+            })}
           </View>
         ))}
       </View>

--- a/apps/viewer/babel.config.js
+++ b/apps/viewer/babel.config.js
@@ -2,5 +2,7 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: [['babel-preset-expo', { jsxImportSource: 'react' }]],
+    // react-native-reanimated/plugin MUST be the LAST plugin.
+    plugins: ['react-native-reanimated/plugin'],
   };
 };

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -29,6 +29,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-native": "0.76.5",
+    "react-native-reanimated": "~3.16.1",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",
     "react-native-web": "~0.19.13",

--- a/apps/viewer/src/domain/use-cases/toggle-camera-mute.use-case.ts
+++ b/apps/viewer/src/domain/use-cases/toggle-camera-mute.use-case.ts
@@ -1,0 +1,77 @@
+// ============================================================
+// ToggleCameraMute — flips the per-camera mute flag in the peers
+// store and best-effort sends an advisory `audio-mute-request`
+// DataChannel message so the camera can stop encoding audio.
+//
+// The DataChannel send is advisory: if the peer is not connected
+// or the channel is not open, the failure is swallowed silently.
+// The store mutation is the source of truth for the UI.
+// ============================================================
+
+import type { DataChannelMessage } from '@sentinel-monitor/shared-types';
+
+export interface MuteAdvisorySender {
+  /**
+   * Best-effort send of an advisory DataChannel message to the camera.
+   * Implementations MUST NOT throw — return false when the channel
+   * is unavailable so callers can log/no-op without try/catch.
+   */
+  send(cameraId: string, message: DataChannelMessage): boolean;
+}
+
+export interface MuteStore {
+  toggleMuted(cameraId: string): boolean;
+  setMuted(cameraId: string, muted: boolean): void;
+  isMuted(cameraId: string): boolean;
+}
+
+export interface ToggleCameraMuteDeps {
+  readonly store: MuteStore;
+  readonly sender?: MuteAdvisorySender;
+  readonly now?: () => number;
+}
+
+export interface ToggleCameraMuteResult {
+  readonly cameraId: string;
+  readonly muted: boolean;
+  readonly advisoryDelivered: boolean;
+}
+
+export class ToggleCameraMuteUseCase {
+  constructor(private readonly deps: ToggleCameraMuteDeps) {}
+
+  execute(cameraId: string): ToggleCameraMuteResult {
+    const { store, sender, now = Date.now } = this.deps;
+    const muted = store.toggleMuted(cameraId);
+    const advisoryDelivered = this.trySend(sender, cameraId, muted, now());
+    return { cameraId, muted, advisoryDelivered };
+  }
+
+  set(cameraId: string, muted: boolean): ToggleCameraMuteResult {
+    const { store, sender, now = Date.now } = this.deps;
+    store.setMuted(cameraId, muted);
+    const advisoryDelivered = this.trySend(sender, cameraId, muted, now());
+    return { cameraId, muted, advisoryDelivered };
+  }
+
+  private trySend(
+    sender: MuteAdvisorySender | undefined,
+    cameraId: string,
+    muted: boolean,
+    ts: number,
+  ): boolean {
+    if (!sender) return false;
+    try {
+      return sender.send(cameraId, {
+        type: 'audio-mute-request',
+        muted,
+        ts,
+      });
+    } catch {
+      // Advisory send is best-effort. Swallow silently to honor the
+      // contract: the UI mute toggle must never fail because of a
+      // missing or broken DataChannel.
+      return false;
+    }
+  }
+}

--- a/apps/viewer/src/presentation/components/camera-tile.component.tsx
+++ b/apps/viewer/src/presentation/components/camera-tile.component.tsx
@@ -1,7 +1,14 @@
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import Animated, {
+  FadeIn,
+  FadeOut,
+  LinearTransition,
+} from 'react-native-reanimated';
 import type { CameraBindingEntity } from '@/domain/entities/camera-binding.entity';
 import type { ConnectionState } from '@sentinel-monitor/shared-types';
-import { getStatusColor, radii, semantic, spacing, typography } from '../theme';
+import { radii, semantic, spacing, typography } from '../theme';
+import { MuteToggle } from './mute-toggle.component';
+import { PresenceDot } from './presence-dot.component';
 import { VideoSurface } from './video-surface';
 
 export interface CameraTileProps {
@@ -9,8 +16,10 @@ export interface CameraTileProps {
   readonly stream?: MediaStream | null;
   readonly state?: ConnectionState;
   readonly online?: boolean;
+  readonly muted?: boolean;
   readonly onPress?: () => void;
   readonly onLongPress?: () => void;
+  readonly onToggleMute?: () => void;
 }
 
 function resolveStatus(
@@ -44,46 +53,64 @@ export function CameraTile({
   stream = null,
   state,
   online,
+  muted = false,
   onPress,
   onLongPress,
+  onToggleMute,
 }: CameraTileProps): JSX.Element {
   const status = resolveStatus(online, state);
-  const statusColor = getStatusColor(status);
   const showVideo = status === 'connected' && stream !== null;
 
   return (
-    <TouchableOpacity
-      style={styles.tile}
-      onPress={onPress}
-      onLongPress={onLongPress}
-      accessibilityLabel={`camera-tile-${binding.id}`}
+    <Animated.View
+      style={styles.tileWrapper}
+      layout={LinearTransition.duration(250)}
+      entering={FadeIn.duration(200)}
+      exiting={FadeOut.duration(150)}
     >
-      <View style={styles.placeholder}>
-        {showVideo ? (
-          <View style={StyleSheet.absoluteFill}>
-            <VideoSurface stream={stream} muted={false} />
-          </View>
-        ) : (
-          <Text style={styles.placeholderText}>{statusLabel(status)}</Text>
-        )}
-      </View>
-      <View style={styles.footer}>
-        <View
-          style={[styles.statusDot, { backgroundColor: statusColor }]}
-          accessibilityLabel={`presence-dot-${status}`}
-        />
-        <Text style={styles.label} numberOfLines={1}>
-          {binding.label}
-        </Text>
-      </View>
-    </TouchableOpacity>
+      <TouchableOpacity
+        style={styles.tile}
+        onPress={onPress}
+        onLongPress={onLongPress}
+        accessibilityLabel={`camera-tile-${binding.id}`}
+        activeOpacity={0.85}
+      >
+        <View style={styles.placeholder}>
+          {showVideo ? (
+            <View style={StyleSheet.absoluteFill}>
+              <VideoSurface stream={stream} muted={muted} />
+            </View>
+          ) : (
+            <Text style={styles.placeholderText}>{statusLabel(status)}</Text>
+          )}
+          {onToggleMute ? (
+            <View style={styles.muteSlot}>
+              <MuteToggle
+                muted={muted}
+                onToggle={onToggleMute}
+                cameraId={binding.id}
+              />
+            </View>
+          ) : null}
+        </View>
+        <View style={styles.footer}>
+          <PresenceDot state={status} />
+          <Text style={styles.label} numberOfLines={1}>
+            {binding.label}
+          </Text>
+        </View>
+      </TouchableOpacity>
+    </Animated.View>
   );
 }
 
 const styles = StyleSheet.create({
-  tile: {
+  tileWrapper: {
     flex: 1,
     margin: spacing[1],
+  },
+  tile: {
+    flex: 1,
     backgroundColor: semantic.bg.surface,
     borderRadius: radii.md,
     overflow: 'hidden',
@@ -100,16 +127,16 @@ const styles = StyleSheet.create({
     color: semantic.text.muted,
     fontSize: typography.size.sm,
   },
+  muteSlot: {
+    position: 'absolute',
+    top: spacing[2],
+    right: spacing[2],
+  },
   footer: {
     flexDirection: 'row',
     alignItems: 'center',
     padding: spacing[2],
     gap: spacing[2],
-  },
-  statusDot: {
-    width: 8,
-    height: 8,
-    borderRadius: radii.full,
   },
   label: {
     color: semantic.text.primary,

--- a/apps/viewer/src/presentation/components/mute-toggle.component.tsx
+++ b/apps/viewer/src/presentation/components/mute-toggle.component.tsx
@@ -1,0 +1,58 @@
+// ============================================================
+// MuteToggle — icon-based, tappable button that flips the audio
+// mute flag for a single camera tile. Pure presentational; the
+// caller owns the state and the actual toggle effect (use case).
+// ============================================================
+
+import { StyleSheet, Text, TouchableOpacity } from 'react-native';
+import { radii, semantic, typography } from '../theme';
+
+export interface MuteToggleProps {
+  readonly muted: boolean;
+  readonly onToggle: () => void;
+  readonly cameraId: string;
+}
+
+export function MuteToggle({
+  muted,
+  onToggle,
+  cameraId,
+}: MuteToggleProps): JSX.Element {
+  return (
+    <TouchableOpacity
+      onPress={(e) => {
+        // Stop bubbling so the parent tile press (fullscreen route)
+        // does not also fire when the user only meant to mute.
+        e.stopPropagation?.();
+        onToggle();
+      }}
+      hitSlop={8}
+      style={styles.button}
+      accessibilityRole="button"
+      accessibilityState={{ checked: muted }}
+      accessibilityLabel={`mute-toggle-${cameraId}`}
+    >
+      <Text style={styles.icon} accessibilityElementsHidden>
+        {muted ? 'M' : 'A'}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    width: 28,
+    height: 28,
+    borderRadius: radii.full,
+    backgroundColor: semantic.bg.elevated,
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: semantic.border.subtle,
+  },
+  icon: {
+    color: semantic.text.primary,
+    fontSize: typography.size.sm,
+    fontWeight: typography.weight.bold,
+  },
+});

--- a/apps/viewer/src/presentation/components/presence-dot.component.tsx
+++ b/apps/viewer/src/presentation/components/presence-dot.component.tsx
@@ -1,0 +1,98 @@
+// ============================================================
+// PresenceDot — small circular indicator that pulses amber while
+// the connection state is `reconnecting`. Animates only opacity
+// and scale (compositor-friendly, no layout thrash).
+// ============================================================
+
+import { useEffect } from 'react';
+import { StyleSheet, View } from 'react-native';
+import Animated, {
+  cancelAnimation,
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from 'react-native-reanimated';
+import type { ConnectionState } from '@sentinel-monitor/shared-types';
+import { getStatusColor, radii, semantic } from '../theme';
+
+const PULSE_DURATION_MS = 900;
+
+export interface PresenceDotProps {
+  readonly state: ConnectionState;
+  readonly size?: number;
+}
+
+export function PresenceDot({
+  state,
+  size = 8,
+}: PresenceDotProps): JSX.Element {
+  const opacity = useSharedValue<number>(1);
+  const scale = useSharedValue<number>(1);
+  const isReconnecting = state === 'reconnecting';
+
+  useEffect(() => {
+    if (isReconnecting) {
+      opacity.value = withRepeat(
+        withTiming(0.35, {
+          duration: PULSE_DURATION_MS,
+          easing: Easing.inOut(Easing.ease),
+        }),
+        -1,
+        true,
+      );
+      scale.value = withRepeat(
+        withTiming(1.35, {
+          duration: PULSE_DURATION_MS,
+          easing: Easing.inOut(Easing.ease),
+        }),
+        -1,
+        true,
+      );
+    } else {
+      cancelAnimation(opacity);
+      cancelAnimation(scale);
+      opacity.value = withTiming(1, { duration: 150 });
+      scale.value = withTiming(1, { duration: 150 });
+    }
+    return () => {
+      cancelAnimation(opacity);
+      cancelAnimation(scale);
+    };
+  }, [isReconnecting, opacity, scale]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ scale: scale.value }],
+  }));
+
+  const color = isReconnecting
+    ? semantic.status.connecting
+    : getStatusColor(state);
+
+  return (
+    <View
+      accessibilityLabel={`presence-dot-${state}`}
+      style={[styles.wrapper, { width: size, height: size }]}
+    >
+      <Animated.View
+        style={[
+          styles.dot,
+          { backgroundColor: color, width: size, height: size },
+          animatedStyle,
+        ]}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  dot: {
+    borderRadius: radii.full,
+  },
+});

--- a/apps/viewer/src/presentation/stores/peers.store.ts
+++ b/apps/viewer/src/presentation/stores/peers.store.ts
@@ -16,8 +16,12 @@ export interface PeerEntry {
 
 export interface PeersState {
   readonly peers: Readonly<Record<string, PeerEntry>>;
+  readonly mutes: Readonly<Record<string, boolean>>;
   readonly setStream: (cameraId: string, stream: MediaStream) => void;
   readonly setState: (cameraId: string, state: ConnectionState) => void;
+  readonly setMuted: (cameraId: string, muted: boolean) => void;
+  readonly toggleMuted: (cameraId: string) => boolean;
+  readonly isMuted: (cameraId: string) => boolean;
   readonly remove: (cameraId: string) => void;
   readonly get: (cameraId: string) => PeerEntry | undefined;
   readonly clear: () => void;
@@ -26,6 +30,7 @@ export interface PeersState {
 export function createPeersStore() {
   return createStore<PeersState>((set, get) => ({
     peers: {},
+    mutes: {},
 
     setStream: (cameraId, stream) => {
       const current = get().peers;
@@ -49,17 +54,37 @@ export function createPeersStore() {
       set({ peers: { ...current, [cameraId]: next } });
     },
 
+    setMuted: (cameraId, muted) => {
+      const current = get().mutes;
+      if (current[cameraId] === muted) return;
+      set({ mutes: { ...current, [cameraId]: muted } });
+    },
+
+    toggleMuted: (cameraId) => {
+      const current = get().mutes;
+      const next = !(current[cameraId] ?? false);
+      set({ mutes: { ...current, [cameraId]: next } });
+      return next;
+    },
+
+    isMuted: (cameraId) => get().mutes[cameraId] ?? false,
+
     remove: (cameraId) => {
       const current = get().peers;
-      if (!(cameraId in current)) return;
-      const next = { ...current };
-      delete next[cameraId];
-      set({ peers: next });
+      const currentMutes = get().mutes;
+      const hadPeer = cameraId in current;
+      const hadMute = cameraId in currentMutes;
+      if (!hadPeer && !hadMute) return;
+      const nextPeers = hadPeer ? { ...current } : current;
+      const nextMutes = hadMute ? { ...currentMutes } : currentMutes;
+      if (hadPeer) delete (nextPeers as Record<string, PeerEntry>)[cameraId];
+      if (hadMute) delete (nextMutes as Record<string, boolean>)[cameraId];
+      set({ peers: nextPeers, mutes: nextMutes });
     },
 
     get: (cameraId) => get().peers[cameraId],
 
-    clear: () => set({ peers: {} }),
+    clear: () => set({ peers: {}, mutes: {} }),
   }));
 }
 

--- a/apps/viewer/tests/unit/peers.store.mute.test.ts
+++ b/apps/viewer/tests/unit/peers.store.mute.test.ts
@@ -1,0 +1,67 @@
+import { createPeersStore } from '@/presentation/stores/peers.store';
+
+describe('peers.store — mute state', () => {
+  it('isMuted defaults to false for unknown ids', () => {
+    const store = createPeersStore();
+    expect(store.getState().isMuted('camera-1')).toBe(false);
+    expect(store.getState().mutes).toEqual({});
+  });
+
+  it('setMuted writes the value', () => {
+    const store = createPeersStore();
+    store.getState().setMuted('camera-1', true);
+    expect(store.getState().isMuted('camera-1')).toBe(true);
+    expect(store.getState().mutes).toEqual({ 'camera-1': true });
+  });
+
+  it('setMuted is a noop when value is unchanged', () => {
+    const store = createPeersStore();
+    store.getState().setMuted('camera-1', true);
+    const before = store.getState().mutes;
+    store.getState().setMuted('camera-1', true);
+    expect(store.getState().mutes).toBe(before);
+  });
+
+  it('toggleMuted flips and returns the new value', () => {
+    const store = createPeersStore();
+    expect(store.getState().toggleMuted('camera-1')).toBe(true);
+    expect(store.getState().isMuted('camera-1')).toBe(true);
+    expect(store.getState().toggleMuted('camera-1')).toBe(false);
+    expect(store.getState().isMuted('camera-1')).toBe(false);
+  });
+
+  it('mute state survives setStream / setState transitions', () => {
+    const store = createPeersStore();
+    store.getState().setMuted('camera-1', true);
+    store.getState().setState('camera-1', 'connecting');
+    store
+      .getState()
+      .setStream('camera-1', { id: 's' } as unknown as MediaStream);
+    expect(store.getState().isMuted('camera-1')).toBe(true);
+  });
+
+  it('remove clears the per-camera mute flag', () => {
+    const store = createPeersStore();
+    store.getState().setState('camera-1', 'connected');
+    store.getState().setMuted('camera-1', true);
+    store.getState().remove('camera-1');
+    expect(store.getState().mutes).toEqual({});
+    expect(store.getState().isMuted('camera-1')).toBe(false);
+  });
+
+  it('remove with only a mute (no peer) still clears it', () => {
+    const store = createPeersStore();
+    store.getState().setMuted('camera-2', true);
+    store.getState().remove('camera-2');
+    expect(store.getState().mutes).toEqual({});
+  });
+
+  it('clear empties mutes alongside peers', () => {
+    const store = createPeersStore();
+    store.getState().setMuted('a', true);
+    store.getState().setState('b', 'connected');
+    store.getState().clear();
+    expect(store.getState().mutes).toEqual({});
+    expect(store.getState().peers).toEqual({});
+  });
+});

--- a/apps/viewer/tests/unit/toggle-camera-mute.use-case.test.ts
+++ b/apps/viewer/tests/unit/toggle-camera-mute.use-case.test.ts
@@ -1,0 +1,113 @@
+import {
+  ToggleCameraMuteUseCase,
+  type MuteAdvisorySender,
+  type MuteStore,
+} from '@/domain/use-cases/toggle-camera-mute.use-case';
+
+function makeStore(): MuteStore & { mutes: Record<string, boolean> } {
+  const mutes: Record<string, boolean> = {};
+  return {
+    mutes,
+    toggleMuted(cameraId: string): boolean {
+      const next = !(mutes[cameraId] ?? false);
+      mutes[cameraId] = next;
+      return next;
+    },
+    setMuted(cameraId: string, muted: boolean): void {
+      mutes[cameraId] = muted;
+    },
+    isMuted(cameraId: string): boolean {
+      return mutes[cameraId] ?? false;
+    },
+  };
+}
+
+describe('ToggleCameraMuteUseCase', () => {
+  it('execute toggles the store and returns the new value', () => {
+    const store = makeStore();
+    const uc = new ToggleCameraMuteUseCase({ store });
+    const result = uc.execute('camera-1');
+    expect(result).toEqual({
+      cameraId: 'camera-1',
+      muted: true,
+      advisoryDelivered: false,
+    });
+    expect(store.isMuted('camera-1')).toBe(true);
+  });
+
+  it('execute toggles back on second call', () => {
+    const store = makeStore();
+    const uc = new ToggleCameraMuteUseCase({ store });
+    uc.execute('camera-1');
+    const result = uc.execute('camera-1');
+    expect(result.muted).toBe(false);
+    expect(store.isMuted('camera-1')).toBe(false);
+  });
+
+  it('set writes the explicit value', () => {
+    const store = makeStore();
+    const uc = new ToggleCameraMuteUseCase({ store });
+    const result = uc.set('camera-2', true);
+    expect(result).toEqual({
+      cameraId: 'camera-2',
+      muted: true,
+      advisoryDelivered: false,
+    });
+    expect(store.isMuted('camera-2')).toBe(true);
+  });
+
+  it('execute fires the advisory sender with the new mute value', () => {
+    const store = makeStore();
+    const send = jest.fn().mockReturnValue(true);
+    const sender: MuteAdvisorySender = { send };
+    const uc = new ToggleCameraMuteUseCase({
+      store,
+      sender,
+      now: () => 12345,
+    });
+    const result = uc.execute('camera-1');
+    expect(send).toHaveBeenCalledWith('camera-1', {
+      type: 'audio-mute-request',
+      muted: true,
+      ts: 12345,
+    });
+    expect(result.advisoryDelivered).toBe(true);
+  });
+
+  it('reports advisoryDelivered=false when sender returns false', () => {
+    const store = makeStore();
+    const sender: MuteAdvisorySender = { send: jest.fn().mockReturnValue(false) };
+    const uc = new ToggleCameraMuteUseCase({ store, sender });
+    expect(uc.execute('camera-1').advisoryDelivered).toBe(false);
+  });
+
+  it('swallows sender exceptions and still toggles the store', () => {
+    const store = makeStore();
+    const sender: MuteAdvisorySender = {
+      send: jest.fn().mockImplementation(() => {
+        throw new Error('peer not connected');
+      }),
+    };
+    const uc = new ToggleCameraMuteUseCase({ store, sender });
+    const result = uc.execute('camera-1');
+    expect(result.advisoryDelivered).toBe(false);
+    expect(result.muted).toBe(true);
+    expect(store.isMuted('camera-1')).toBe(true);
+  });
+
+  it('set forwards the explicit muted flag to the sender', () => {
+    const store = makeStore();
+    const send = jest.fn().mockReturnValue(true);
+    const uc = new ToggleCameraMuteUseCase({
+      store,
+      sender: { send },
+      now: () => 999,
+    });
+    uc.set('camera-9', false);
+    expect(send).toHaveBeenCalledWith('camera-9', {
+      type: 'audio-mute-request',
+      muted: false,
+      ts: 999,
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,7 +117,7 @@ importers:
         version: 7.0.5(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
       expo-router:
         specifier: ~4.0.0
-        version: 4.0.22(3u2flrxlunxzfm7hjeknxu32su)
+        version: 4.0.22(pylli4d255ua2o5lal6f5ht45u)
       expo-status-bar:
         specifier: ~2.0.0
         version: 2.0.1(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
@@ -130,6 +130,9 @@ importers:
       react-native:
         specifier: 0.76.5
         version: 0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)
+      react-native-reanimated:
+        specifier: ~3.16.1
+        version: 3.16.7(@babel/core@7.29.0)(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
       react-native-safe-area-context:
         specifier: 4.12.0
         version: 4.12.0(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
@@ -4271,6 +4274,13 @@ packages:
   react-native-is-edge-to-edge@1.3.1:
     resolution: {integrity: sha512-NIXU/iT5+ORyCc7p0z2nnlkouYKX425vuU1OEm6bMMtWWR9yvb+Xg5AZmImTKoF9abxCPqrKC3rOZsKzUYgYZA==}
     peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  react-native-reanimated@3.16.7:
+    resolution: {integrity: sha512-qoUUQOwE1pHlmQ9cXTJ2MX9FQ9eHllopCLiWOkDkp6CER95ZWeXhJCP4cSm6AD4jigL5jHcZf/SkWrg8ttZUsw==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
       react: '*'
       react-native: '*'
 
@@ -8492,7 +8502,7 @@ snapshots:
     dependencies:
       invariant: 2.2.4
 
-  expo-router@4.0.22(3u2flrxlunxzfm7hjeknxu32su):
+  expo-router@4.0.22(pylli4d255ua2o5lal6f5ht45u):
     dependencies:
       '@expo/metro-runtime': 4.0.1(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))
       '@expo/server': 0.5.3
@@ -8512,6 +8522,8 @@ snapshots:
       schema-utils: 4.3.3
       semver: 7.6.3
       server-only: 0.0.1
+    optionalDependencies:
+      react-native-reanimated: 3.16.7(@babel/core@7.29.0)(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
       - react
@@ -10294,6 +10306,25 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-native: 0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)
+
+  react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      convert-source-map: 2.0.0
+      invariant: 2.2.4
+      react: 18.3.1
+      react-native: 0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)
+    transitivePeerDependencies:
+      - supports-color
 
   react-native-safe-area-context@4.12.0(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Summary
- Tap any grid tile to open `/camera/[id]` fullscreen with the stream unmuted and a back button to return to the grid.
- Per-tile `MuteToggle` flips a UI-only flag in the peers store and best-effort emits an `audio-mute-request` advisory through an injected DataChannel sender (failures swallowed silently).
- New `PresenceDot` pulses amber while the connection state is `reconnecting` using compositor-only animations (opacity + scale via `useSharedValue` / `useAnimatedStyle`), no layout thrash.
- Grid mounts / unmounts ride `react-native-reanimated` `LinearTransition` + `FadeIn` / `FadeOut` for smooth reflow when cameras are added or removed.
- Adds `react-native-reanimated` (Expo SDK 52 compatible) and registers its Babel plugin LAST.
- New `ToggleCameraMuteUseCase` in `domain/use-cases` with full unit coverage (100%) plus dedicated `peers.store` mute tests.

Closes #8

## Test plan
- [x] `pnpm typecheck` — green across all 6 packages
- [x] `pnpm --filter @sentinel-monitor/viewer test` — 17 suites / 105 tests pass
- [x] Coverage on `toggle-camera-mute.use-case.ts` = 100%; `peers.store.ts` = 97.77% statements / 100% branches (well above the 80% threshold)
- [ ] Manual: tap a tile → fullscreen route opens, audio unmuted, back button returns to grid
- [ ] Manual: mute button on a tile flips the icon and does not trigger the fullscreen navigation
- [ ] Manual: while a peer is reconnecting, the presence dot pulses amber smoothly (no jank on a low-end Android)
- [ ] Manual: adding / removing cameras animates the grid without abrupt jumps