### PR TITLE
feat(viewer): reconnect hardening — ICE restart + socket reconverge

### DIFF
--- a/apps/viewer/src/domain/repositories/i-signaling.repository.ts
+++ b/apps/viewer/src/domain/repositories/i-signaling.repository.ts
@@ -31,4 +31,12 @@ export interface ISignalingRepository {
   offSignal(handler: (signal: SignalDto) => void): void;
   onPresenceChange(handler: (change: PresenceChangeDto) => void): void;
   offPresenceChange(handler: (change: PresenceChangeDto) => void): void;
+
+  /**
+   * Subscribe to socket reconnect events. The handler is invoked AFTER
+   * the underlying transport has re-established a connection and
+   * presence/subscription state needs to be re-emitted by callers.
+   */
+  onReconnect(handler: () => void): void;
+  offReconnect(handler: () => void): void;
 }

--- a/apps/viewer/src/domain/use-cases/start-viewer-session.use-case.ts
+++ b/apps/viewer/src/domain/use-cases/start-viewer-session.use-case.ts
@@ -54,10 +54,16 @@ export class StartViewerSessionUseCase {
     if (cameraIds.length === 0) {
       const noopHandler = (_change: PresenceChangeDto): void => undefined;
       signaling.onPresenceChange(noopHandler);
+      const noopReconnect = (): void => {
+        // No bindings — only re-register presence on reconnect.
+        signaling.registerPresence(dashboardId);
+      };
+      signaling.onReconnect(noopReconnect);
       return {
         connections,
         stop: async () => {
           signaling.offPresenceChange(noopHandler);
+          signaling.offReconnect(noopReconnect);
         },
       };
     }
@@ -103,10 +109,54 @@ export class StartViewerSessionUseCase {
 
     signaling.onPresenceChange(presenceHandler);
 
+    const reconnectHandler = (): void => {
+      // Reconverge after a transport reconnect:
+      //   1. Re-register presence (server may have forgotten us)
+      //   2. Re-subscribe to the same camera set
+      //   3. Re-query the current presence snapshot
+      //   4. Drop peers that are no longer online; connect to fresh ones
+      signaling.registerPresence(dashboardId);
+      signaling.subscribePresence(cameraIds);
+      void signaling
+        .queryPresence(cameraIds)
+        .then((snap) => {
+          onPresenceSnapshot(snap.online);
+          const onlineSet = new Set(snap.online);
+          // Close stale peers — anything we held open but is now offline.
+          for (const [id, conn] of connections) {
+            if (!onlineSet.has(id)) {
+              conn.close();
+              connections.delete(id);
+              onPresenceChange(id, false);
+            }
+          }
+          // Open fresh peers for online cameras we don't already have.
+          for (const id of snap.online) {
+            if (connections.has(id)) continue;
+            void connectToCamera
+              .execute(id)
+              .then((conn) => {
+                connections.set(id, conn);
+                onPresenceChange(id, true);
+              })
+              .catch((err) => {
+                // eslint-disable-next-line no-console
+                console.warn(`[viewer] reconnect (re-converge) failed for ${id}`, err);
+              });
+          }
+        })
+        .catch((err) => {
+          // eslint-disable-next-line no-console
+          console.warn('[viewer] reconnect re-query failed', err);
+        });
+    };
+    signaling.onReconnect(reconnectHandler);
+
     return {
       connections,
       stop: async () => {
         signaling.offPresenceChange(presenceHandler);
+        signaling.offReconnect(reconnectHandler);
         for (const conn of connections.values()) conn.close();
         connections.clear();
       },

--- a/apps/viewer/src/infrastructure/signaling/socketio-signaling.client.ts
+++ b/apps/viewer/src/infrastructure/signaling/socketio-signaling.client.ts
@@ -30,6 +30,14 @@ const defaultFactory = (url: string): TypedSocket =>
   io(url, {
     autoConnect: false,
     transports: ['websocket'],
+    // Socket.IO already implements exponential backoff with jitter — we
+    // make the configuration explicit so reconnection behavior is
+    // documented and predictable across environments.
+    reconnection: true,
+    reconnectionAttempts: Infinity,
+    reconnectionDelay: 1_000,
+    reconnectionDelayMax: 10_000,
+    randomizationFactor: 0.5,
   }) as TypedSocket;
 
 function isPairingError(
@@ -44,10 +52,24 @@ function isPairingError(
 
 export class SocketIoSignalingClient implements ISignalingRepository {
   private readonly socket: TypedSocket;
+  private readonly reconnectHandlers = new Set<() => void>();
+  private hasConnectedOnce = false;
 
   constructor(options: SocketIoSignalingClientOptions) {
     const factory = options.socketFactory ?? defaultFactory;
     this.socket = factory(options.url);
+
+    // Socket.IO emits `connect` on both the initial connect and every
+    // subsequent automatic reconnect. We treat any post-initial
+    // `connect` as a reconnect signal so callers can re-emit
+    // presence/subscriptions and reconverge their state.
+    this.socket.on('connect', () => {
+      if (!this.hasConnectedOnce) {
+        this.hasConnectedOnce = true;
+        return;
+      }
+      for (const handler of this.reconnectHandlers) handler();
+    });
   }
 
   connect(): Promise<void> {
@@ -130,5 +152,13 @@ export class SocketIoSignalingClient implements ISignalingRepository {
 
   offPresenceChange(handler: (change: PresenceChangeDto) => void): void {
     this.socket.off('presence-change', handler);
+  }
+
+  onReconnect(handler: () => void): void {
+    this.reconnectHandlers.add(handler);
+  }
+
+  offReconnect(handler: () => void): void {
+    this.reconnectHandlers.delete(handler);
   }
 }

--- a/apps/viewer/src/infrastructure/webrtc/webrtc-subscriber.web.ts
+++ b/apps/viewer/src/infrastructure/webrtc/webrtc-subscriber.web.ts
@@ -18,7 +18,16 @@ export interface BrowserWebRtcSubscriberOptions {
   readonly emitSignal: (payload: SignalPayload) => void;
   readonly rtcConfig?: RTCConfiguration;
   readonly peerFactory?: PeerFactory;
+  /**
+   * Minimum interval (ms) between consecutive ICE restart attempts.
+   * Prevents tight restart loops when the connection flaps. Defaults to 5000.
+   */
+  readonly iceRestartMinIntervalMs?: number;
+  /** Override the time source — primarily for tests. */
+  readonly now?: () => number;
 }
+
+const DEFAULT_ICE_RESTART_MIN_INTERVAL_MS = 5_000;
 
 export class BrowserWebRtcSubscriber implements IWebRtcSubscriberRepository {
   private readonly pc: RTCPeerConnection;
@@ -26,10 +35,17 @@ export class BrowserWebRtcSubscriber implements IWebRtcSubscriberRepository {
   private remoteStream: MediaStream | null = null;
   private trackHandler: ((stream: MediaStream) => void) | null = null;
   private stateHandler: ((state: SubscriberState) => void) | null = null;
+  private lastIceRestartAt: number | null = null;
+  private iceRestartInFlight = false;
+  private readonly iceRestartMinIntervalMs: number;
+  private readonly now: () => number;
 
   constructor(private readonly options: BrowserWebRtcSubscriberOptions) {
     const factory = options.peerFactory ?? ((c) => new RTCPeerConnection(c));
     this.pc = factory(options.rtcConfig ?? WEBRTC_CONFIG);
+    this.iceRestartMinIntervalMs =
+      options.iceRestartMinIntervalMs ?? DEFAULT_ICE_RESTART_MIN_INTERVAL_MS;
+    this.now = options.now ?? ((): number => Date.now());
 
     this.pc.ontrack = (event): void => {
       // Prefer the stream the remote attached the track to. Fallback
@@ -51,6 +67,44 @@ export class BrowserWebRtcSubscriber implements IWebRtcSubscriberRepository {
     this.pc.onconnectionstatechange = (): void => {
       this.setState(mapPeerState(this.pc.connectionState));
     };
+
+    this.pc.oniceconnectionstatechange = (): void => {
+      if (this.pc.iceConnectionState === 'disconnected') {
+        void this.maybeRestartIce();
+      }
+    };
+  }
+
+  /**
+   * Trigger an ICE restart, debounced so we don't loop on a flapping
+   * connection. Generates a fresh offer with `iceRestart: true` and
+   * forwards it through the signaling channel; the camera will reply
+   * with a new answer carrying refreshed ICE credentials.
+   */
+  private async maybeRestartIce(): Promise<void> {
+    if (this.iceRestartInFlight) return;
+    if (this.state === 'closed') return;
+    const ts = this.now();
+    if (
+      this.lastIceRestartAt !== null &&
+      ts - this.lastIceRestartAt < this.iceRestartMinIntervalMs
+    ) {
+      return;
+    }
+
+    this.iceRestartInFlight = true;
+    this.lastIceRestartAt = ts;
+    try {
+      this.pc.restartIce();
+      const offer = await this.pc.createOffer({ iceRestart: true });
+      await this.pc.setLocalDescription(offer);
+      this.options.emitSignal({ type: 'offer', sdp: offer.sdp ?? '' });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn('[viewer] ICE restart failed', err);
+    } finally {
+      this.iceRestartInFlight = false;
+    }
   }
 
   async connect(_cameraId: string): Promise<void> {

--- a/apps/viewer/tests/unit/connect-to-camera.use-case.test.ts
+++ b/apps/viewer/tests/unit/connect-to-camera.use-case.test.ts
@@ -94,6 +94,8 @@ function createFakeSignaling(): FakeSignaling {
     offPresenceChange: (h) => {
       f.presenceHandlers = f.presenceHandlers.filter((x) => x !== h);
     },
+    onReconnect: () => undefined,
+    offReconnect: () => undefined,
   };
   return f;
 }

--- a/apps/viewer/tests/unit/socketio-signaling.client.reconnect.test.ts
+++ b/apps/viewer/tests/unit/socketio-signaling.client.reconnect.test.ts
@@ -1,0 +1,131 @@
+// ============================================================
+// Reconnect-path coverage for the Socket.IO signaling client:
+// the second `connect` event triggers registered reconnect handlers,
+// and offReconnect properly removes them.
+// ============================================================
+
+import {
+  SocketIoSignalingClient,
+  type TypedSocket,
+} from '@/infrastructure/signaling/socketio-signaling.client';
+
+interface FakeSocket {
+  connected: boolean;
+  listeners: Record<string, Array<(...a: unknown[]) => void>>;
+  socket: TypedSocket;
+  dispatch: (event: string, ...args: unknown[]) => void;
+}
+
+function createFakeSocket(): FakeSocket {
+  const f: FakeSocket = {
+    connected: false,
+    listeners: {},
+    socket: {} as TypedSocket,
+    dispatch: () => undefined,
+  };
+  f.dispatch = (event, ...args): void => {
+    (f.listeners[event] ?? []).forEach((fn) => fn(...args));
+  };
+  f.socket = {
+    get connected() {
+      return f.connected;
+    },
+    connect: () => {
+      f.connected = true;
+      f.dispatch('connect');
+    },
+    disconnect: () => {
+      f.connected = false;
+      f.dispatch('disconnect');
+    },
+    emit: () => undefined,
+    on: (event: string, handler: (...a: unknown[]) => void) => {
+      (f.listeners[event] ??= []).push(handler);
+    },
+    off: (event: string, handler?: (...a: unknown[]) => void) => {
+      if (!handler) {
+        f.listeners[event] = [];
+        return;
+      }
+      f.listeners[event] = (f.listeners[event] ?? []).filter((h) => h !== handler);
+    },
+    once: () => undefined,
+  } as unknown as TypedSocket;
+  return f;
+}
+
+describe('SocketIoSignalingClient — reconnect handlers', () => {
+  it('registers a "connect" listener on the socket immediately', () => {
+    const fake = createFakeSocket();
+    new SocketIoSignalingClient({
+      url: 'http://x',
+      socketFactory: () => fake.socket,
+    });
+    expect(fake.listeners.connect).toHaveLength(1);
+  });
+
+  it('does not invoke reconnect handlers on the very first connect', () => {
+    const fake = createFakeSocket();
+    const client = new SocketIoSignalingClient({
+      url: 'http://x',
+      socketFactory: () => fake.socket,
+    });
+    const handler = jest.fn();
+    client.onReconnect(handler);
+
+    fake.dispatch('connect');
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('invokes reconnect handlers on each subsequent connect (simulated drop + reconnect)', () => {
+    const fake = createFakeSocket();
+    const client = new SocketIoSignalingClient({
+      url: 'http://x',
+      socketFactory: () => fake.socket,
+    });
+    const handler = jest.fn();
+    client.onReconnect(handler);
+
+    // First connect = bootstrap.
+    fake.dispatch('connect');
+    // Drop and reconnect.
+    fake.dispatch('disconnect');
+    fake.dispatch('connect');
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // Another flap.
+    fake.dispatch('disconnect');
+    fake.dispatch('connect');
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it('offReconnect removes the handler', () => {
+    const fake = createFakeSocket();
+    const client = new SocketIoSignalingClient({
+      url: 'http://x',
+      socketFactory: () => fake.socket,
+    });
+    const handler = jest.fn();
+    client.onReconnect(handler);
+    fake.dispatch('connect'); // bootstrap
+    client.offReconnect(handler);
+    fake.dispatch('connect'); // would-be reconnect
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('supports multiple independent reconnect handlers', () => {
+    const fake = createFakeSocket();
+    const client = new SocketIoSignalingClient({
+      url: 'http://x',
+      socketFactory: () => fake.socket,
+    });
+    const a = jest.fn();
+    const b = jest.fn();
+    client.onReconnect(a);
+    client.onReconnect(b);
+    fake.dispatch('connect');
+    fake.dispatch('connect');
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/viewer/tests/unit/start-viewer-session.reconnect.test.ts
+++ b/apps/viewer/tests/unit/start-viewer-session.reconnect.test.ts
@@ -1,0 +1,301 @@
+// ============================================================
+// Reconnect re-converge coverage for StartViewerSessionUseCase:
+// when the signaling client fires `onReconnect`, the use case must
+// re-register presence, re-subscribe to the cameras, re-query the
+// presence snapshot, drop stale peers and connect to fresh ones.
+// ============================================================
+
+import { StartViewerSessionUseCase } from '@/domain/use-cases/start-viewer-session.use-case';
+import type {
+  CameraConnection,
+  ConnectToCameraUseCase,
+} from '@/domain/use-cases/connect-to-camera.use-case';
+import type { ISignalingRepository } from '@/domain/repositories/i-signaling.repository';
+import { CameraBindingEntity } from '@/domain/entities/camera-binding.entity';
+import type { PresenceChangeDto } from '@sentinel-monitor/shared-types';
+
+interface FakeSignaling {
+  connected: boolean;
+  registerCalls: string[];
+  subscribeCalls: Array<readonly string[]>;
+  queryCalls: Array<readonly string[]>;
+  presenceHandlers: Array<(c: PresenceChangeDto) => void>;
+  reconnectHandlers: Array<() => void>;
+  queryQueue: Array<{ online: readonly string[] }>;
+  repo: ISignalingRepository;
+}
+
+function createFakeSignaling(initialQuery: { online: readonly string[] }): FakeSignaling {
+  const f: FakeSignaling = {
+    connected: true,
+    registerCalls: [],
+    subscribeCalls: [],
+    queryCalls: [],
+    presenceHandlers: [],
+    reconnectHandlers: [],
+    queryQueue: [initialQuery],
+    repo: {} as ISignalingRepository,
+  };
+  f.repo = {
+    connect: async () => {
+      f.connected = true;
+    },
+    disconnect: () => {
+      f.connected = false;
+    },
+    isConnected: () => f.connected,
+    registerPresence: (id) => f.registerCalls.push(id),
+    redeemPairingCode: async () => ({
+      success: true,
+      data: { cameraId: 'c', dashboardId: 'd' },
+    }),
+    queryPresence: async (ids) => {
+      f.queryCalls.push(ids);
+      return f.queryQueue.shift() ?? { online: [] };
+    },
+    subscribePresence: (ids) => f.subscribeCalls.push(ids),
+    sendSignal: () => undefined,
+    onSignal: () => undefined,
+    offSignal: () => undefined,
+    onPresenceChange: (h) => f.presenceHandlers.push(h),
+    offPresenceChange: (h) => {
+      f.presenceHandlers = f.presenceHandlers.filter((x) => x !== h);
+    },
+    onReconnect: (h) => f.reconnectHandlers.push(h),
+    offReconnect: (h) => {
+      f.reconnectHandlers = f.reconnectHandlers.filter((x) => x !== h);
+    },
+  };
+  return f;
+}
+
+interface RecordedConnect {
+  cameraId: string;
+  closed: boolean;
+  conn: CameraConnection;
+}
+
+function createConnectStub(failFor: Set<string> = new Set()): {
+  uc: ConnectToCameraUseCase;
+  records: RecordedConnect[];
+} {
+  const records: RecordedConnect[] = [];
+  const uc = {
+    async execute(cameraId: string): Promise<CameraConnection> {
+      if (failFor.has(cameraId)) throw new Error(`boom-${cameraId}`);
+      const rec: RecordedConnect = {
+        cameraId,
+        closed: false,
+        conn: {} as CameraConnection,
+      };
+      rec.conn = {
+        cameraId,
+        subscriber: {} as never,
+        close: () => {
+          rec.closed = true;
+        },
+      };
+      records.push(rec);
+      return rec.conn;
+    },
+  } as unknown as ConnectToCameraUseCase;
+  return { uc, records };
+}
+
+function makeBinding(cameraId: string, idx: number): CameraBindingEntity {
+  return CameraBindingEntity.create({
+    id: `binding-${idx}`,
+    cameraId,
+    label: `Camera ${idx}`,
+    addedAt: idx,
+  });
+}
+
+async function flush(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+describe('StartViewerSessionUseCase — reconnect re-converge', () => {
+  it('on reconnect: re-registers presence, re-subscribes, re-queries presence and reconnects fresh online cameras', async () => {
+    const signaling = createFakeSignaling({ online: ['cam-A'] });
+    // Second response (post-reconnect): cam-A drops, cam-B comes online.
+    signaling.queryQueue.push({ online: ['cam-B'] });
+    const { uc: connectUC, records } = createConnectStub();
+    const snapshots: string[][] = [];
+    const changes: Array<[string, boolean]> = [];
+
+    const useCase = new StartViewerSessionUseCase({
+      signaling: signaling.repo,
+      connectToCamera: connectUC,
+      dashboardId: 'dash-1',
+      onPresenceSnapshot: (online) => snapshots.push([...online]),
+      onPresenceChange: (id, online) => changes.push([id, online]),
+    });
+
+    const session = await useCase.execute({
+      bindings: [makeBinding('cam-A', 1), makeBinding('cam-B', 2)],
+    });
+
+    expect(signaling.registerCalls).toEqual(['dash-1']);
+    expect(signaling.subscribeCalls).toEqual([['cam-A', 'cam-B']]);
+    expect(signaling.queryCalls).toEqual([['cam-A', 'cam-B']]);
+    expect(records.map((r) => r.cameraId)).toEqual(['cam-A']);
+    expect(session.connections.has('cam-A')).toBe(true);
+
+    // Simulate socket drop + reconnect.
+    expect(signaling.reconnectHandlers).toHaveLength(1);
+    signaling.reconnectHandlers[0]!();
+    await flush();
+
+    // Re-registered + re-subscribed + re-queried.
+    expect(signaling.registerCalls).toEqual(['dash-1', 'dash-1']);
+    expect(signaling.subscribeCalls).toEqual([
+      ['cam-A', 'cam-B'],
+      ['cam-A', 'cam-B'],
+    ]);
+    expect(signaling.queryCalls).toHaveLength(2);
+
+    // Snapshot updated.
+    expect(snapshots).toEqual([['cam-A'], ['cam-B']]);
+
+    // Stale peer cam-A was closed; cam-B was opened.
+    const camA = records.find((r) => r.cameraId === 'cam-A')!;
+    expect(camA.closed).toBe(true);
+    expect(records.map((r) => r.cameraId)).toEqual(['cam-A', 'cam-B']);
+    expect(session.connections.has('cam-A')).toBe(false);
+    expect(session.connections.has('cam-B')).toBe(true);
+
+    // Presence change callbacks fired for the deltas.
+    expect(changes).toEqual(
+      expect.arrayContaining([
+        ['cam-A', false],
+        ['cam-B', true],
+      ]),
+    );
+  });
+
+  it('reconnect handler keeps existing peers when they remain online', async () => {
+    const signaling = createFakeSignaling({ online: ['cam-A'] });
+    signaling.queryQueue.push({ online: ['cam-A'] });
+    const { uc: connectUC, records } = createConnectStub();
+
+    const useCase = new StartViewerSessionUseCase({
+      signaling: signaling.repo,
+      connectToCamera: connectUC,
+      dashboardId: 'dash-1',
+      onPresenceSnapshot: () => undefined,
+      onPresenceChange: () => undefined,
+    });
+    const session = await useCase.execute({
+      bindings: [makeBinding('cam-A', 1)],
+    });
+
+    signaling.reconnectHandlers[0]!();
+    await flush();
+
+    // cam-A should NOT have been re-opened nor closed.
+    expect(records.filter((r) => r.cameraId === 'cam-A')).toHaveLength(1);
+    expect(records[0]!.closed).toBe(false);
+    expect(session.connections.has('cam-A')).toBe(true);
+  });
+
+  it('logs and continues when the re-query fails', async () => {
+    const signaling = createFakeSignaling({ online: [] });
+    // Make the next queryPresence reject.
+    const original = signaling.repo.queryPresence;
+    let calls = 0;
+    signaling.repo = {
+      ...signaling.repo,
+      queryPresence: async (ids) => {
+        calls += 1;
+        if (calls === 2) throw new Error('network');
+        return original(ids);
+      },
+    };
+    const { uc: connectUC } = createConnectStub();
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const useCase = new StartViewerSessionUseCase({
+      signaling: signaling.repo,
+      connectToCamera: connectUC,
+      dashboardId: 'dash-1',
+      onPresenceSnapshot: () => undefined,
+      onPresenceChange: () => undefined,
+    });
+    await useCase.execute({ bindings: [makeBinding('cam-A', 1)] });
+
+    signaling.reconnectHandlers[0]!();
+    await flush();
+
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('logs and continues when reconnect-driven connect fails for one camera', async () => {
+    const signaling = createFakeSignaling({ online: [] });
+    signaling.queryQueue.push({ online: ['cam-A', 'cam-B'] });
+    const failFor = new Set<string>(['cam-A']);
+    const { uc: connectUC, records } = createConnectStub(failFor);
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const useCase = new StartViewerSessionUseCase({
+      signaling: signaling.repo,
+      connectToCamera: connectUC,
+      dashboardId: 'dash-1',
+      onPresenceSnapshot: () => undefined,
+      onPresenceChange: () => undefined,
+    });
+    const session = await useCase.execute({
+      bindings: [makeBinding('cam-A', 1), makeBinding('cam-B', 2)],
+    });
+
+    signaling.reconnectHandlers[0]!();
+    await flush();
+
+    expect(records.map((r) => r.cameraId)).toEqual(['cam-B']);
+    expect(session.connections.has('cam-B')).toBe(true);
+    expect(session.connections.has('cam-A')).toBe(false);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('with no bindings, reconnect handler still re-registers presence', async () => {
+    const signaling = createFakeSignaling({ online: [] });
+    const { uc: connectUC } = createConnectStub();
+
+    const useCase = new StartViewerSessionUseCase({
+      signaling: signaling.repo,
+      connectToCamera: connectUC,
+      dashboardId: 'dash-1',
+      onPresenceSnapshot: () => undefined,
+      onPresenceChange: () => undefined,
+    });
+    const session = await useCase.execute({ bindings: [] });
+
+    expect(signaling.reconnectHandlers).toHaveLength(1);
+    signaling.reconnectHandlers[0]!();
+    expect(signaling.registerCalls).toEqual(['dash-1', 'dash-1']);
+
+    await session.stop();
+    expect(signaling.reconnectHandlers).toHaveLength(0);
+  });
+
+  it('stop() unsubscribes the reconnect handler', async () => {
+    const signaling = createFakeSignaling({ online: [] });
+    const { uc: connectUC } = createConnectStub();
+    const useCase = new StartViewerSessionUseCase({
+      signaling: signaling.repo,
+      connectToCamera: connectUC,
+      dashboardId: 'dash-1',
+      onPresenceSnapshot: () => undefined,
+      onPresenceChange: () => undefined,
+    });
+    const session = await useCase.execute({
+      bindings: [makeBinding('cam-A', 1)],
+    });
+    expect(signaling.reconnectHandlers).toHaveLength(1);
+    await session.stop();
+    expect(signaling.reconnectHandlers).toHaveLength(0);
+  });
+});

--- a/apps/viewer/tests/unit/start-viewer-session.use-case.test.ts
+++ b/apps/viewer/tests/unit/start-viewer-session.use-case.test.ts
@@ -14,6 +14,7 @@ interface FakeSignaling {
   subscribeCalls: Array<readonly string[]>;
   queryCalls: Array<readonly string[]>;
   presenceHandlers: Array<(c: PresenceChangeDto) => void>;
+  reconnectHandlers: Array<() => void>;
   queryResult: { online: readonly string[] };
   repo: ISignalingRepository;
 }
@@ -26,6 +27,7 @@ function createFakeSignaling(initiallyConnected = false): FakeSignaling {
     subscribeCalls: [],
     queryCalls: [],
     presenceHandlers: [],
+    reconnectHandlers: [],
     queryResult: { online: [] },
     repo: {} as ISignalingRepository,
   };
@@ -60,6 +62,12 @@ function createFakeSignaling(initiallyConnected = false): FakeSignaling {
     },
     offPresenceChange: (h) => {
       f.presenceHandlers = f.presenceHandlers.filter((x) => x !== h);
+    },
+    onReconnect: (h) => {
+      f.reconnectHandlers.push(h);
+    },
+    offReconnect: (h) => {
+      f.reconnectHandlers = f.reconnectHandlers.filter((x) => x !== h);
     },
   };
   return f;

--- a/apps/viewer/tests/unit/webrtc-subscriber.web.reconnect.test.ts
+++ b/apps/viewer/tests/unit/webrtc-subscriber.web.reconnect.test.ts
@@ -1,0 +1,204 @@
+// ============================================================
+// Reconnect-path coverage for the browser WebRTC subscriber:
+// ICE restart on `iceconnectionstate === 'disconnected'`,
+// debounced so a flapping connection does not trigger a loop.
+// ============================================================
+
+import {
+  BrowserWebRtcSubscriber,
+  type PeerFactory,
+} from '@/infrastructure/webrtc/webrtc-subscriber.web';
+import type { SignalPayload } from '@sentinel-monitor/shared-types';
+
+interface FakePeerConnection {
+  iceConnectionState: RTCIceConnectionState;
+  connectionState: RTCPeerConnectionState;
+  oniceconnectionstatechange: (() => void) | null;
+  onconnectionstatechange: (() => void) | null;
+  ontrack: ((e: RTCTrackEvent) => void) | null;
+  onicecandidate: ((e: RTCPeerConnectionIceEvent) => void) | null;
+  restartIce: jest.Mock;
+  createOffer: jest.Mock;
+  setLocalDescription: jest.Mock;
+  setRemoteDescription: jest.Mock;
+  addIceCandidate: jest.Mock;
+  addTransceiver: jest.Mock;
+  close: jest.Mock;
+  // Test helper: trip the ICE state.
+  __tripIce(state: RTCIceConnectionState): void;
+}
+
+function createFakePeer(): FakePeerConnection {
+  const fake: FakePeerConnection = {
+    iceConnectionState: 'new',
+    connectionState: 'new',
+    oniceconnectionstatechange: null,
+    onconnectionstatechange: null,
+    ontrack: null,
+    onicecandidate: null,
+    restartIce: jest.fn(),
+    createOffer: jest.fn(async (opts?: RTCOfferOptions) => ({
+      type: 'offer' as RTCSdpType,
+      sdp: opts?.iceRestart ? 'v=0-restart' : 'v=0',
+    })),
+    setLocalDescription: jest.fn(async () => undefined),
+    setRemoteDescription: jest.fn(async () => undefined),
+    addIceCandidate: jest.fn(async () => undefined),
+    addTransceiver: jest.fn(),
+    close: jest.fn(),
+    __tripIce(state) {
+      fake.iceConnectionState = state;
+      fake.oniceconnectionstatechange?.();
+    },
+  };
+  return fake;
+}
+
+function buildSubscriber(opts: {
+  emitted: SignalPayload[];
+  fake: FakePeerConnection;
+  now?: () => number;
+  intervalMs?: number;
+}): BrowserWebRtcSubscriber {
+  const factory: PeerFactory = () => opts.fake as unknown as RTCPeerConnection;
+  return new BrowserWebRtcSubscriber({
+    emitSignal: (p) => opts.emitted.push(p),
+    peerFactory: factory,
+    iceRestartMinIntervalMs: opts.intervalMs,
+    now: opts.now,
+  });
+}
+
+describe('BrowserWebRtcSubscriber — ICE reconnect path', () => {
+  it('calls restartIce + emits a fresh iceRestart offer when ICE goes disconnected', async () => {
+    const fake = createFakePeer();
+    const emitted: SignalPayload[] = [];
+    let t = 0;
+    buildSubscriber({ emitted, fake, now: () => t, intervalMs: 5_000 });
+
+    fake.__tripIce('disconnected');
+    // Drain microtasks so the async restart finishes.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fake.restartIce).toHaveBeenCalledTimes(1);
+    expect(fake.createOffer).toHaveBeenCalledWith({ iceRestart: true });
+    expect(fake.setLocalDescription).toHaveBeenCalledTimes(1);
+    expect(emitted).toEqual([{ type: 'offer', sdp: 'v=0-restart' }]);
+  });
+
+  it('debounces consecutive ICE disconnects within the min interval', async () => {
+    const fake = createFakePeer();
+    const emitted: SignalPayload[] = [];
+    let t = 1_000;
+    buildSubscriber({ emitted, fake, now: () => t, intervalMs: 5_000 });
+
+    fake.__tripIce('disconnected');
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fake.restartIce).toHaveBeenCalledTimes(1);
+
+    // Bounce again only 1s later — must be debounced.
+    t = 2_000;
+    fake.__tripIce('disconnected');
+    await Promise.resolve();
+    expect(fake.restartIce).toHaveBeenCalledTimes(1);
+    expect(emitted).toHaveLength(1);
+  });
+
+  it('allows a second restart once the min interval has elapsed', async () => {
+    const fake = createFakePeer();
+    const emitted: SignalPayload[] = [];
+    let t = 0;
+    buildSubscriber({ emitted, fake, now: () => t, intervalMs: 5_000 });
+
+    fake.__tripIce('disconnected');
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fake.restartIce).toHaveBeenCalledTimes(1);
+
+    t = 10_000;
+    fake.__tripIce('disconnected');
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fake.restartIce).toHaveBeenCalledTimes(2);
+    expect(emitted).toHaveLength(2);
+  });
+
+  it('ignores ICE state changes other than "disconnected"', async () => {
+    const fake = createFakePeer();
+    const emitted: SignalPayload[] = [];
+    buildSubscriber({ emitted, fake });
+    fake.__tripIce('connected');
+    fake.__tripIce('checking');
+    fake.__tripIce('completed');
+    await Promise.resolve();
+    expect(fake.restartIce).not.toHaveBeenCalled();
+    expect(emitted).toHaveLength(0);
+  });
+
+  it('does not restart when the subscriber has been closed', async () => {
+    const fake = createFakePeer();
+    const emitted: SignalPayload[] = [];
+    const sub = buildSubscriber({ emitted, fake });
+    sub.close();
+    fake.__tripIce('disconnected');
+    await Promise.resolve();
+    expect(fake.restartIce).not.toHaveBeenCalled();
+  });
+
+  it('swallows restart errors via the warn channel and does not throw', async () => {
+    const fake = createFakePeer();
+    fake.createOffer = jest.fn(async () => {
+      throw new Error('boom');
+    });
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const emitted: SignalPayload[] = [];
+    buildSubscriber({ emitted, fake });
+
+    fake.__tripIce('disconnected');
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(warn).toHaveBeenCalled();
+    expect(emitted).toHaveLength(0);
+    warn.mockRestore();
+  });
+
+  it('does not run a second restart while one is already in-flight', async () => {
+    const fake = createFakePeer();
+    const releaseRef: { fn: (() => void) | null } = { fn: null };
+    fake.createOffer = jest.fn(
+      () =>
+        new Promise<RTCSessionDescriptionInit>((resolve) => {
+          releaseRef.fn = (): void =>
+            resolve({ type: 'offer' as RTCSdpType, sdp: 'v=0-restart' });
+        }),
+    );
+    const emitted: SignalPayload[] = [];
+    let t = 0;
+    buildSubscriber({ emitted, fake, now: () => t, intervalMs: 1 });
+
+    fake.__tripIce('disconnected');
+    await Promise.resolve();
+    expect(fake.restartIce).toHaveBeenCalledTimes(1);
+
+    // Even though enough time has elapsed, a second trip should be ignored
+    // until the in-flight restart resolves.
+    t = 500;
+    fake.__tripIce('disconnected');
+    await Promise.resolve();
+    expect(fake.restartIce).toHaveBeenCalledTimes(1);
+
+    // Resolve the pending restart.
+    releaseRef.fn?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(emitted).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Browser WebRTC subscriber now reacts to `iceConnectionState === 'disconnected'` by calling `pc.restartIce()` and emitting a fresh `iceRestart` offer through the signaling channel. The path is debounced (default 5s) and guarded against re-entry while a restart is in flight, so a flapping link cannot trigger a restart loop.
- Socket.IO signaling client wires explicit reconnection options (infinite attempts, 1s→10s exponential backoff with jitter) and exposes `onReconnect` / `offReconnect`. The first `connect` event is treated as bootstrap; every subsequent `connect` fans out to registered handlers.
- `StartViewerSessionUseCase` registers a reconnect handler that re-emits `register-presence`, re-`subscribe-presence`, re-`query-presence`, closes peers that are no longer online and opens fresh peers for any newly online camera. `stop()` tears the handler down.
- `ISignalingRepository` extended with `onReconnect` / `offReconnect` to keep the viewer session use case decoupled from the transport.

## Test plan
- [x] `pnpm typecheck` GREEN
- [x] `pnpm --filter @sentinel-monitor/viewer test` — 108/108 passing, coverage 98% lines / 96% branches
- [x] New `webrtc-subscriber.web.reconnect.test.ts` covers ICE restart trigger, debounce window, in-flight guard, post-close no-op, error swallow
- [x] New `socketio-signaling.client.reconnect.test.ts` covers bootstrap-vs-reconnect distinction, multi-handler fan-out, off
- [x] New `start-viewer-session.reconnect.test.ts` simulates a socket drop and asserts re-register + re-subscribe + re-query + stale-close + fresh-connect
- [x] Existing `start-viewer-session` and `connect-to-camera` test fakes updated for the new repository surface

Closes #9