### PR TITLE
fix(repo): node-linker=hoisted for Expo Universal + pnpm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# Expo + monorepo + pnpm requires hoisted layout because react-native-web,
+# expo-router, expo-modules-core and other RN packages do undeclared
+# transitive requires that pnpm's default strict resolution rejects.
+# See: https://docs.expo.dev/guides/monorepos/#package-managers
+node-linker=hoisted


### PR DESCRIPTION
Closes #28

Stops the whack-a-mole of patching individual peer deps. `.npmrc` with `node-linker=hoisted` flattens `node_modules` so Expo + react-native-web's transitive requires resolve cleanly. Per [official Expo monorepo docs](https://docs.expo.dev/guides/monorepos/#package-managers).

## Test plan
- [x] `pnpm typecheck` green (6/6)
- [x] `pnpm test` green (3/3 packages, 258 tests)
- [ ] Manual: `./start` boots viewer-web without bundling errors