### PR TITLE
feat(gateway): go2rtc adapter (REST client + optional process manager)

### DIFF
--- a/apps/gateway/src/domain/repositories/i-go2rtc-client.repository.ts
+++ b/apps/gateway/src/domain/repositories/i-go2rtc-client.repository.ts
@@ -1,0 +1,31 @@
+// go2rtc is the LAN bridge that ingests RTSP from IP cams and re-publishes
+// each as a WebRTC stream over its WHEP endpoint. The gateway talks to
+// it over HTTP only — never instantiates RTCPeerConnection itself for the
+// camera side. That keeps the gateway portable to Pi/ARM (no native deps).
+
+export interface Go2RtcStreamHealth {
+  readonly streamId: string;
+  readonly online: boolean;
+  readonly producers: number;
+}
+
+export interface IGo2RtcClient {
+  /** GET /api/streams — succeeds when go2rtc reachable. */
+  health(): Promise<{ ok: true; version?: string }>;
+
+  /** POST /api/streams?name=streamId&src=rtspUrl — registers an RTSP source. */
+  registerStream(streamId: string, rtspUrl: string): Promise<void>;
+
+  /** DELETE /api/streams?src=streamId — removes a previously registered source. */
+  removeStream(streamId: string): Promise<void>;
+
+  /** Per-stream health snapshot, useful for liveness checks. */
+  getStreamHealth(streamId: string): Promise<Go2RtcStreamHealth>;
+
+  /**
+   * URL the dashboard's WebRTC subscriber consumes via WHEP (WebRTC-HTTP
+   * Egress Protocol). The gateway proxies this URL through the signaling
+   * server so the dashboard never sees the LAN address directly.
+   */
+  getWhepUrl(streamId: string): string;
+}

--- a/apps/gateway/src/infrastructure/go2rtc/go2rtc-process.manager.ts
+++ b/apps/gateway/src/infrastructure/go2rtc/go2rtc-process.manager.ts
@@ -1,0 +1,62 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import type { ILogger } from '../logging/logger';
+
+// Optional: spawn the go2rtc binary as a subprocess of the gateway. In
+// production we run go2rtc as a sibling docker container (compose file)
+// so this is dev-only convenience. Toggled via env GATEWAY_SPAWN_GO2RTC=true.
+
+export interface Go2RtcProcessOptions {
+  readonly binaryPath?: string; // defaults to 'go2rtc' on PATH
+  readonly configPath?: string; // YAML config file for go2rtc
+  readonly logger: ILogger;
+}
+
+export class Go2RtcProcessManager {
+  private child: ChildProcess | null = null;
+
+  constructor(private readonly opts: Go2RtcProcessOptions) {}
+
+  async start(): Promise<void> {
+    if (this.child) return;
+    const binary = this.opts.binaryPath ?? 'go2rtc';
+    const args = this.opts.configPath ? ['-config', this.opts.configPath] : [];
+
+    this.child = spawn(binary, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    this.opts.logger.info(
+      { event: 'go2rtc.spawned', pid: this.child.pid, binary },
+      'go2rtc subprocess started',
+    );
+
+    this.child.stdout?.on('data', (chunk: Buffer) => {
+      this.opts.logger.debug({ event: 'go2rtc.stdout', line: chunk.toString().trim() });
+    });
+    this.child.stderr?.on('data', (chunk: Buffer) => {
+      this.opts.logger.debug({ event: 'go2rtc.stderr', line: chunk.toString().trim() });
+    });
+    this.child.on('exit', (code) => {
+      this.opts.logger.warn({ event: 'go2rtc.exited', code }, 'go2rtc subprocess exited');
+      this.child = null;
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (!this.child) return;
+    return new Promise<void>((resolve) => {
+      const child = this.child!;
+      const onExit = (): void => {
+        this.child = null;
+        resolve();
+      };
+      child.once('exit', onExit);
+      child.kill('SIGTERM');
+      // Hard kill after 5s if still alive.
+      setTimeout(() => {
+        if (this.child) child.kill('SIGKILL');
+      }, 5_000);
+    });
+  }
+
+  isRunning(): boolean {
+    return this.child !== null;
+  }
+}

--- a/apps/gateway/src/infrastructure/go2rtc/go2rtc.client.ts
+++ b/apps/gateway/src/infrastructure/go2rtc/go2rtc.client.ts
@@ -1,0 +1,96 @@
+import type {
+  Go2RtcStreamHealth,
+  IGo2RtcClient,
+} from '../../domain/repositories/i-go2rtc-client.repository';
+
+export interface Go2RtcClientOptions {
+  readonly baseUrl: string; // e.g. http://127.0.0.1:1984
+  readonly fetchImpl?: typeof fetch; // injectable for tests
+  readonly timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+interface Go2RtcStreamsResponse {
+  readonly [streamId: string]:
+    | {
+        readonly producers?: ReadonlyArray<{ readonly url?: string; readonly state?: string }>;
+        readonly consumers?: readonly unknown[];
+      }
+    | undefined;
+}
+
+export class Go2RtcClient implements IGo2RtcClient {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+
+  constructor(opts: Go2RtcClientOptions) {
+    this.baseUrl = opts.baseUrl.replace(/\/+$/, '');
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  async health(): Promise<{ ok: true; version?: string }> {
+    const res = await this.request('GET', '/api/streams');
+    if (!res.ok) {
+      throw new Error(`go2rtc health failed: HTTP ${res.status}`);
+    }
+    const versionHeader = res.headers.get('server') ?? undefined;
+    return { ok: true, version: versionHeader };
+  }
+
+  async registerStream(streamId: string, rtspUrl: string): Promise<void> {
+    if (!rtspUrl.startsWith('rtsp://')) {
+      throw new Error(`registerStream: rtspUrl must start with rtsp:// (got "${rtspUrl}")`);
+    }
+    const url = `/api/streams?name=${encodeURIComponent(streamId)}&src=${encodeURIComponent(rtspUrl)}`;
+    const res = await this.request('PUT', url);
+    if (!res.ok) {
+      throw new Error(`registerStream(${streamId}) failed: HTTP ${res.status}`);
+    }
+  }
+
+  async removeStream(streamId: string): Promise<void> {
+    const url = `/api/streams?src=${encodeURIComponent(streamId)}`;
+    const res = await this.request('DELETE', url);
+    if (!res.ok && res.status !== 404) {
+      throw new Error(`removeStream(${streamId}) failed: HTTP ${res.status}`);
+    }
+  }
+
+  async getStreamHealth(streamId: string): Promise<Go2RtcStreamHealth> {
+    const res = await this.request('GET', '/api/streams');
+    if (!res.ok) {
+      throw new Error(`getStreamHealth: HTTP ${res.status}`);
+    }
+    const streams = (await res.json()) as Go2RtcStreamsResponse;
+    const entry = streams[streamId];
+    if (!entry) {
+      return { streamId, online: false, producers: 0 };
+    }
+    const producers = entry.producers ?? [];
+    return {
+      streamId,
+      online: producers.length > 0,
+      producers: producers.length,
+    };
+  }
+
+  getWhepUrl(streamId: string): string {
+    return `${this.baseUrl}/api/webrtc?src=${encodeURIComponent(streamId)}`;
+  }
+
+  private async request(method: string, path: string): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      return await this.fetchImpl(`${this.baseUrl}${path}`, {
+        method,
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/apps/gateway/tests/unit/go2rtc-process.manager.test.ts
+++ b/apps/gateway/tests/unit/go2rtc-process.manager.test.ts
@@ -1,0 +1,55 @@
+import { Go2RtcProcessManager } from '../../src/infrastructure/go2rtc/go2rtc-process.manager';
+
+const silentLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  child: jest.fn(),
+};
+
+describe('Go2RtcProcessManager', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    silentLogger.child.mockReturnValue(silentLogger);
+  });
+
+  it('isRunning() returns false before start', () => {
+    const mgr = new Go2RtcProcessManager({ logger: silentLogger });
+    expect(mgr.isRunning()).toBe(false);
+  });
+
+  it('start() with a non-existent binary still resolves and the exit handler clears the child', async () => {
+    const mgr = new Go2RtcProcessManager({
+      binaryPath: '/usr/bin/false', // exists on linux/mac, exits non-zero immediately
+      logger: silentLogger,
+    });
+    await mgr.start();
+    // Wait a tick for the spawn-then-exit cycle to fire on the event loop.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mgr.isRunning()).toBe(false);
+    // The "exited" warn log fired.
+    expect(silentLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'go2rtc.exited' }),
+      expect.any(String),
+    );
+  });
+
+  it('start() is idempotent (does not spawn twice)', async () => {
+    const mgr = new Go2RtcProcessManager({
+      binaryPath: 'sleep', // Use sleep so the process stays alive long enough for the test
+      logger: silentLogger,
+    });
+    // We can't easily inject child_process.spawn — instead, verify
+    // start() returns and doesn't blow up when called twice rapidly.
+    await mgr.start();
+    await mgr.start();
+    await mgr.stop();
+    expect(mgr.isRunning()).toBe(false);
+  });
+
+  it('stop() before start() is a no-op', async () => {
+    const mgr = new Go2RtcProcessManager({ logger: silentLogger });
+    await expect(mgr.stop()).resolves.toBeUndefined();
+  });
+});

--- a/apps/gateway/tests/unit/go2rtc.client.test.ts
+++ b/apps/gateway/tests/unit/go2rtc.client.test.ts
@@ -1,0 +1,163 @@
+import { Go2RtcClient } from '../../src/infrastructure/go2rtc/go2rtc.client';
+
+interface FetchCall {
+  url: string;
+  method: string;
+  signal: AbortSignal | null;
+}
+
+const makeFetch = (impl: (call: FetchCall) => Response | Promise<Response>) => {
+  const calls: FetchCall[] = [];
+  const fn = (async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const call: FetchCall = {
+      url,
+      method: init?.method ?? 'GET',
+      signal: init?.signal ?? null,
+    };
+    calls.push(call);
+    return impl(call);
+  }) as typeof fetch;
+  return { fn, calls };
+};
+
+const ok = (body: unknown = {}, headers: Record<string, string> = {}): Response =>
+  new Response(JSON.stringify(body), { status: 200, headers });
+
+const fail = (status = 500): Response => new Response('', { status });
+
+describe('Go2RtcClient', () => {
+  describe('health', () => {
+    it('returns ok + version header on 200', async () => {
+      const { fn } = makeFetch(() => ok({}, { server: 'go2rtc/1.9.10' }));
+      const client = new Go2RtcClient({ baseUrl: 'http://127.0.0.1:1984', fetchImpl: fn });
+      const result = await client.health();
+      expect(result).toEqual({ ok: true, version: 'go2rtc/1.9.10' });
+    });
+
+    it('throws on non-200', async () => {
+      const { fn } = makeFetch(() => fail(503));
+      const client = new Go2RtcClient({ baseUrl: 'http://127.0.0.1:1984', fetchImpl: fn });
+      await expect(client.health()).rejects.toThrow(/HTTP 503/);
+    });
+
+    it('uses GET on /api/streams', async () => {
+      const { fn, calls } = makeFetch(() => ok());
+      const client = new Go2RtcClient({ baseUrl: 'http://127.0.0.1:1984', fetchImpl: fn });
+      await client.health();
+      expect(calls[0]!.method).toBe('GET');
+      expect(calls[0]!.url).toBe('http://127.0.0.1:1984/api/streams');
+    });
+  });
+
+  describe('registerStream', () => {
+    it('PUTs streams API with name + src params', async () => {
+      const { fn, calls } = makeFetch(() => ok());
+      const client = new Go2RtcClient({ baseUrl: 'http://127.0.0.1:1984', fetchImpl: fn });
+      await client.registerStream('cam-1', 'rtsp://u:p@192.168.0.42:554/stream1');
+
+      expect(calls[0]!.method).toBe('PUT');
+      expect(calls[0]!.url).toContain('/api/streams');
+      expect(calls[0]!.url).toContain('name=cam-1');
+      expect(calls[0]!.url).toContain('src=rtsp%3A%2F%2Fu%3Ap%40192.168.0.42%3A554%2Fstream1');
+    });
+
+    it('rejects non-rtsp URLs without hitting the network', async () => {
+      const { fn, calls } = makeFetch(() => ok());
+      const client = new Go2RtcClient({ baseUrl: 'http://127.0.0.1:1984', fetchImpl: fn });
+      await expect(client.registerStream('cam-1', 'http://example.com/stream')).rejects.toThrow(
+        /must start with rtsp/,
+      );
+      expect(calls).toHaveLength(0);
+    });
+
+    it('throws when go2rtc rejects the registration', async () => {
+      const { fn } = makeFetch(() => fail(400));
+      const client = new Go2RtcClient({ baseUrl: 'http://127.0.0.1:1984', fetchImpl: fn });
+      await expect(client.registerStream('cam-1', 'rtsp://u:p@host:554/s1')).rejects.toThrow(
+        /HTTP 400/,
+      );
+    });
+  });
+
+  describe('removeStream', () => {
+    it('DELETEs the stream by id', async () => {
+      const { fn, calls } = makeFetch(() => ok());
+      const client = new Go2RtcClient({ baseUrl: 'http://127.0.0.1:1984', fetchImpl: fn });
+      await client.removeStream('cam-1');
+      expect(calls[0]!.method).toBe('DELETE');
+      expect(calls[0]!.url).toContain('src=cam-1');
+    });
+
+    it('treats 404 as success (already removed is fine)', async () => {
+      const { fn } = makeFetch(() => fail(404));
+      const client = new Go2RtcClient({ baseUrl: 'http://127.0.0.1:1984', fetchImpl: fn });
+      await expect(client.removeStream('cam-1')).resolves.toBeUndefined();
+    });
+
+    it('throws on other failures', async () => {
+      const { fn } = makeFetch(() => fail(500));
+      const client = new Go2RtcClient({ baseUrl: 'http://127.0.0.1:1984', fetchImpl: fn });
+      await expect(client.removeStream('cam-1')).rejects.toThrow(/HTTP 500/);
+    });
+  });
+
+  describe('getStreamHealth', () => {
+    it('reports online + producer count when stream exists', async () => {
+      const { fn } = makeFetch(() =>
+        ok({
+          'cam-1': { producers: [{ url: 'rtsp://...', state: 'connected' }] },
+        }),
+      );
+      const client = new Go2RtcClient({ baseUrl: 'http://127.0.0.1:1984', fetchImpl: fn });
+      const result = await client.getStreamHealth('cam-1');
+      expect(result).toEqual({ streamId: 'cam-1', online: true, producers: 1 });
+    });
+
+    it('reports offline + 0 when stream missing', async () => {
+      const { fn } = makeFetch(() => ok({}));
+      const client = new Go2RtcClient({ baseUrl: 'http://127.0.0.1:1984', fetchImpl: fn });
+      const result = await client.getStreamHealth('cam-1');
+      expect(result).toEqual({ streamId: 'cam-1', online: false, producers: 0 });
+    });
+
+    it('reports offline when producers empty', async () => {
+      const { fn } = makeFetch(() => ok({ 'cam-1': { producers: [] } }));
+      const client = new Go2RtcClient({ baseUrl: 'http://127.0.0.1:1984', fetchImpl: fn });
+      const result = await client.getStreamHealth('cam-1');
+      expect(result).toEqual({ streamId: 'cam-1', online: false, producers: 0 });
+    });
+  });
+
+  describe('getWhepUrl', () => {
+    it('builds a properly-encoded URL', () => {
+      const client = new Go2RtcClient({ baseUrl: 'http://127.0.0.1:1984', fetchImpl: fetch });
+      expect(client.getWhepUrl('cam-1')).toBe('http://127.0.0.1:1984/api/webrtc?src=cam-1');
+    });
+
+    it('strips trailing slash from baseUrl', () => {
+      const client = new Go2RtcClient({ baseUrl: 'http://127.0.0.1:1984/', fetchImpl: fetch });
+      expect(client.getWhepUrl('cam-1')).toBe('http://127.0.0.1:1984/api/webrtc?src=cam-1');
+    });
+  });
+
+  describe('timeout', () => {
+    it('aborts via AbortSignal when timeout fires', async () => {
+      // Hang forever; abort signal should reject the request.
+      const { fn } = makeFetch(
+        ({ signal }) =>
+          new Promise<Response>((_, reject) => {
+            signal?.addEventListener('abort', () =>
+              reject(new DOMException('aborted', 'AbortError')),
+            );
+          }),
+      );
+      const client = new Go2RtcClient({
+        baseUrl: 'http://127.0.0.1:1984',
+        fetchImpl: fn,
+        timeoutMs: 50,
+      });
+      await expect(client.health()).rejects.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Closes #32

PR-G2 of the gateway sprint. Wraps go2rtc with a typed `IGo2RtcClient` interface so the gateway can register RTSP sources and proxy WHEP URLs without ever instantiating native WebRTC bindings (keeps the gateway portable to ARM/Pi).

## Delivered
- `IGo2RtcClient` interface (health, registerStream, removeStream, getStreamHealth, getWhepUrl)
- `Go2RtcClient`: fetch-based HTTP client with AbortController timeout, RTSP scheme validation, 404-as-success on remove
- `Go2RtcProcessManager`: optional dev-mode subprocess spawn (production uses sibling docker container)

## Tests
- **32 tests / 4 suites** passing (19 new for go2rtc)
- Coverage: 92% stmts / 95.87% lines

## Out of scope (next PRs)
- PR-G3 #33: signaling client + per-camera WebRTC publisher
- PR-G4 #34: pairing flow
- PR-G5 #35: docker-compose + smoke