### PR TITLE
feat(gateway): signaling client + per-camera WebRTC publisher (WHEP proxy)

### DIFF
--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -17,6 +17,7 @@
     "@sentinel-monitor/shared-types": "workspace:*",
     "@sentinel-monitor/webrtc-config": "workspace:*",
     "pino": "^9.5.0",
+    "socket.io-client": "^4.8.0",
     "yaml": "^2.6.0",
     "zod": "^3.23.0"
   },

--- a/apps/gateway/src/domain/repositories/i-camera-publisher.repository.ts
+++ b/apps/gateway/src/domain/repositories/i-camera-publisher.repository.ts
@@ -1,0 +1,26 @@
+import type { SignalPayload } from '@sentinel-monitor/shared-types';
+
+// Per-camera publisher. NOT a real RTCPeerConnection — proxies SDP
+// offers/answers between viewer ↔ go2rtc WHEP. Keeps the gateway free
+// of native WebRTC bindings (works on ARM/Pi without compilation).
+
+export interface ICameraPublisher {
+  /**
+   * Process an inbound signal from a viewer (offer or ICE candidate).
+   * Returns the outbound signal to send back, or null when nothing to
+   * forward (e.g., trickle ICE candidates that don't need an answer).
+   */
+  handleViewerSignal(
+    fromDashboardId: string,
+    payload: SignalPayload,
+  ): Promise<SignalPayload | null>;
+
+  /** Tear down the WHEP session for a specific dashboard. */
+  closeSession(fromDashboardId: string): Promise<void>;
+
+  /** Tear down all sessions. Used on camera stop. */
+  closeAllSessions(): Promise<void>;
+
+  /** Number of active sessions (one per connected dashboard). */
+  sessionCount(): number;
+}

--- a/apps/gateway/src/domain/repositories/i-signaling.repository.ts
+++ b/apps/gateway/src/domain/repositories/i-signaling.repository.ts
@@ -1,0 +1,27 @@
+import type { SignalDto } from '@sentinel-monitor/shared-types';
+
+// Gateway-side signaling client. Each camera owns one connection (one
+// `peerId = cameraId`) and listens for inbound signals + presence
+// changes from the dashboards that paired with it.
+
+export interface ISignalingClient {
+  /** Establishes the Socket.IO connection. Idempotent. */
+  connect(signalingUrl: string): Promise<void>;
+
+  /** Closes the connection cleanly. */
+  disconnect(): Promise<void>;
+
+  /** Announces this peer is online. Must be called after connect(). */
+  registerPresence(peerId: string): void;
+
+  /** Outbound signal (camera → dashboard). */
+  sendSignal(payload: SignalDto): void;
+
+  /** Subscribe to signals where toPeerId === our peer id. */
+  onSignal(handler: (payload: SignalDto) => void): void;
+
+  /** Subscribe to presence changes for the dashboards paired with our camera. */
+  onPresenceChange(
+    handler: (event: { peerId: string; online: boolean }) => void,
+  ): void;
+}

--- a/apps/gateway/src/domain/use-cases/start-camera.use-case.ts
+++ b/apps/gateway/src/domain/use-cases/start-camera.use-case.ts
@@ -1,0 +1,80 @@
+import type { CameraConfig } from '../entities/camera-config.entity';
+import type { ICameraPublisher } from '../repositories/i-camera-publisher.repository';
+import type { ISignalingClient } from '../repositories/i-signaling.repository';
+import type { IGo2RtcClient } from '../repositories/i-go2rtc-client.repository';
+
+export interface StartCameraDeps {
+  readonly signaling: ISignalingClient;
+  readonly publisher: ICameraPublisher;
+  readonly go2rtc: IGo2RtcClient;
+}
+
+export interface StartCameraInput {
+  readonly camera: CameraConfig;
+  readonly signalingUrl: string;
+}
+
+export type StartCameraResult =
+  | { readonly started: true }
+  | { readonly started: false; readonly reason: string };
+
+/**
+ * Brings one camera online end-to-end:
+ *   1. Register the RTSP source with the local go2rtc bridge.
+ *   2. Connect to the signaling server with the camera's stable UUID.
+ *   3. Wire incoming viewer signals to the publisher.
+ *   4. Wire publisher answers/candidates back to viewers.
+ *   5. On viewer disconnect, tear down its WHEP session.
+ */
+export class StartCameraUseCase {
+  constructor(private readonly deps: StartCameraDeps) {}
+
+  async execute(input: StartCameraInput): Promise<StartCameraResult> {
+    try {
+      await this.deps.go2rtc.registerStream(input.camera.id, input.camera.rtspUrl);
+    } catch (err) {
+      return {
+        started: false,
+        reason: `go2rtc.registerStream failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    try {
+      await this.deps.signaling.connect(input.signalingUrl);
+    } catch (err) {
+      return {
+        started: false,
+        reason: `signaling.connect failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    this.deps.signaling.registerPresence(input.camera.id);
+
+    this.deps.signaling.onSignal(async (signal) => {
+      // Only handle signals addressed to this camera.
+      if (signal.toPeerId !== input.camera.id) return;
+
+      const reply = await this.deps.publisher.handleViewerSignal(
+        signal.fromPeerId,
+        signal.payload,
+      );
+
+      if (reply) {
+        this.deps.signaling.sendSignal({
+          fromPeerId: input.camera.id,
+          toPeerId: signal.fromPeerId,
+          payload: reply,
+        });
+      }
+    });
+
+    this.deps.signaling.onPresenceChange((event) => {
+      if (!event.online) {
+        // Dashboard disconnected — close its session if any.
+        void this.deps.publisher.closeSession(event.peerId);
+      }
+    });
+
+    return { started: true };
+  }
+}

--- a/apps/gateway/src/domain/use-cases/stop-camera.use-case.ts
+++ b/apps/gateway/src/domain/use-cases/stop-camera.use-case.ts
@@ -1,0 +1,30 @@
+import type { ICameraPublisher } from '../repositories/i-camera-publisher.repository';
+import type { ISignalingClient } from '../repositories/i-signaling.repository';
+import type { IGo2RtcClient } from '../repositories/i-go2rtc-client.repository';
+
+export interface StopCameraDeps {
+  readonly signaling: ISignalingClient;
+  readonly publisher: ICameraPublisher;
+  readonly go2rtc: IGo2RtcClient;
+}
+
+export interface StopCameraInput {
+  readonly cameraId: string;
+}
+
+/**
+ * Tears down everything for a single camera. Idempotent.
+ */
+export class StopCameraUseCase {
+  constructor(private readonly deps: StopCameraDeps) {}
+
+  async execute(input: StopCameraInput): Promise<void> {
+    await this.deps.publisher.closeAllSessions();
+    await this.deps.signaling.disconnect();
+    try {
+      await this.deps.go2rtc.removeStream(input.cameraId);
+    } catch {
+      // Best-effort: if go2rtc went away, we still consider the camera stopped.
+    }
+  }
+}

--- a/apps/gateway/src/infrastructure/signaling/socketio-signaling.client.ts
+++ b/apps/gateway/src/infrastructure/signaling/socketio-signaling.client.ts
@@ -1,0 +1,118 @@
+import { io, type Socket } from 'socket.io-client';
+import type {
+  IClientToServerEvents,
+  IServerToClientEvents,
+  PresenceChangeDto,
+  SignalDto,
+} from '@sentinel-monitor/shared-types';
+import type { ISignalingClient } from '../../domain/repositories/i-signaling.repository';
+import type { ILogger } from '../logging/logger';
+
+type TypedSocket = Socket<IServerToClientEvents, IClientToServerEvents>;
+
+export interface SocketIoSignalingClientOptions {
+  readonly logger: ILogger;
+  readonly socketFactory?: (url: string) => TypedSocket;
+}
+
+export class SocketIoSignalingClient implements ISignalingClient {
+  private socket: TypedSocket | null = null;
+  private readonly logger: ILogger;
+  private readonly socketFactory: (url: string) => TypedSocket;
+  private signalHandler: ((p: SignalDto) => void) | null = null;
+  private presenceHandler: ((e: PresenceChangeDto) => void) | null = null;
+
+  constructor(opts: SocketIoSignalingClientOptions) {
+    this.logger = opts.logger;
+    this.socketFactory =
+      opts.socketFactory ??
+      ((url) =>
+        io(url, {
+          transports: ['websocket'],
+          reconnection: true,
+          reconnectionAttempts: Infinity,
+          reconnectionDelay: 1_000,
+          reconnectionDelayMax: 10_000,
+          randomizationFactor: 0.5,
+        }) as TypedSocket);
+  }
+
+  async connect(signalingUrl: string): Promise<void> {
+    if (this.socket && this.socket.connected) return;
+
+    this.socket = this.socketFactory(signalingUrl);
+
+    this.socket.on('connect', () => {
+      this.logger.info(
+        { event: 'signaling.connected', socketId: this.socket?.id },
+        'Signaling socket connected',
+      );
+    });
+
+    this.socket.on('disconnect', (reason) => {
+      this.logger.warn(
+        { event: 'signaling.disconnected', reason },
+        'Signaling socket disconnected',
+      );
+    });
+
+    this.socket.on('signal', (payload: SignalDto) => {
+      this.signalHandler?.(payload);
+    });
+
+    this.socket.on('presence-change', (event: PresenceChangeDto) => {
+      this.presenceHandler?.(event);
+    });
+
+    return new Promise<void>((resolve, reject) => {
+      const sock = this.socket!;
+      const onConnect = (): void => {
+        sock.off('connect_error', onError);
+        resolve();
+      };
+      const onError = (err: Error): void => {
+        sock.off('connect', onConnect);
+        reject(err);
+      };
+      sock.once('connect', onConnect);
+      sock.once('connect_error', onError);
+    });
+  }
+
+  async disconnect(): Promise<void> {
+    if (!this.socket) return;
+    this.socket.removeAllListeners();
+    this.socket.disconnect();
+    this.socket = null;
+  }
+
+  registerPresence(peerId: string): void {
+    if (!this.socket) {
+      throw new Error('registerPresence: signaling not connected');
+    }
+    this.socket.emit('register-presence', { peerId, role: 'camera' });
+    this.logger.info(
+      { event: 'signaling.presence_registered', peerId },
+      'Camera presence registered',
+    );
+  }
+
+  sendSignal(payload: SignalDto): void {
+    if (!this.socket) {
+      this.logger.debug(
+        { event: 'signaling.send_dropped_no_socket' },
+        'sendSignal called before connect — dropping',
+      );
+      return;
+    }
+    this.socket.emit('signal', payload);
+  }
+
+  onSignal(handler: (payload: SignalDto) => void): void {
+    this.signalHandler = handler;
+  }
+
+  onPresenceChange(handler: (event: PresenceChangeDto) => void): void {
+    this.presenceHandler = handler;
+  }
+}

--- a/apps/gateway/src/infrastructure/webrtc/gateway-camera-publisher.ts
+++ b/apps/gateway/src/infrastructure/webrtc/gateway-camera-publisher.ts
@@ -1,0 +1,170 @@
+import type {
+  ICameraPublisher,
+} from '../../domain/repositories/i-camera-publisher.repository';
+import type { SignalPayload } from '@sentinel-monitor/shared-types';
+import type { ILogger } from '../logging/logger';
+
+interface WhepSession {
+  /** Resource URL returned in WHEP Location header — used for trickle/teardown. */
+  resourceUrl: string;
+}
+
+export interface GatewayCameraPublisherOptions {
+  readonly cameraId: string;
+  readonly streamId: string; // go2rtc stream id (often === cameraId)
+  readonly whepBaseUrl: string; // e.g. http://127.0.0.1:1984/api/webrtc?src=streamId
+  readonly fetchImpl?: typeof fetch;
+  readonly logger: ILogger;
+}
+
+/**
+ * Bridges WebRTC signaling between a viewer and the local go2rtc instance
+ * via WHEP (WebRTC-HTTP Egress Protocol). The gateway never instantiates
+ * an RTCPeerConnection — go2rtc holds the actual peer.
+ *
+ * Flow per dashboard:
+ *   viewer offer →  POST whepUrl  →  go2rtc returns 201 + answer SDP + Location
+ *   viewer ICE candidate (trickle) → PATCH resourceUrl + sdpFrag (best effort)
+ *   teardown → DELETE resourceUrl
+ *
+ * Limitations:
+ *   - Trickle ICE from gateway → viewer is not modeled; go2rtc returns
+ *     non-trickle SDP (all candidates inline) which works for most networks.
+ *   - We swallow viewer ICE PATCH failures so the session still works
+ *     when go2rtc doesn't support trickle on its WHEP impl.
+ */
+export class GatewayCameraPublisher implements ICameraPublisher {
+  private readonly sessions = new Map<string, WhepSession>();
+  private readonly fetchImpl: typeof fetch;
+  private readonly logger: ILogger;
+
+  constructor(private readonly opts: GatewayCameraPublisherOptions) {
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+    this.logger = opts.logger.child({ cameraId: opts.cameraId });
+  }
+
+  async handleViewerSignal(
+    fromDashboardId: string,
+    payload: SignalPayload,
+  ): Promise<SignalPayload | null> {
+    if (payload.type === 'offer') {
+      return this.handleOffer(fromDashboardId, payload.sdp);
+    }
+    if (payload.type === 'ice-candidate') {
+      await this.handleIceCandidate(fromDashboardId, payload.candidate);
+      return null;
+    }
+    // Answers don't apply: gateway is the answerer side.
+    this.logger.debug(
+      { event: 'publisher.unexpected_answer', from: fromDashboardId },
+      'Received an answer from viewer; gateway only handles offers/candidates',
+    );
+    return null;
+  }
+
+  private async handleOffer(
+    fromDashboardId: string,
+    offerSdp: string,
+  ): Promise<SignalPayload> {
+    // Tear down a stale session before opening a new one (renegotiation).
+    if (this.sessions.has(fromDashboardId)) {
+      await this.closeSession(fromDashboardId);
+    }
+
+    const res = await this.fetchImpl(this.opts.whepBaseUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/sdp' },
+      body: offerSdp,
+    });
+
+    if (!res.ok) {
+      this.logger.error(
+        { event: 'publisher.whep_offer_failed', from: fromDashboardId, status: res.status },
+        'go2rtc WHEP rejected the offer',
+      );
+      throw new Error(`WHEP offer failed: HTTP ${res.status}`);
+    }
+
+    const answerSdp = await res.text();
+    const resourceUrl = res.headers.get('location') ?? '';
+    this.sessions.set(fromDashboardId, { resourceUrl });
+
+    this.logger.info(
+      { event: 'publisher.session_opened', from: fromDashboardId, hasResource: !!resourceUrl },
+      'WHEP session opened for dashboard',
+    );
+
+    return { type: 'answer', sdp: answerSdp };
+  }
+
+  private async handleIceCandidate(
+    fromDashboardId: string,
+    candidate: RTCIceCandidateInit,
+  ): Promise<void> {
+    const session = this.sessions.get(fromDashboardId);
+    if (!session || !session.resourceUrl) {
+      // Either the session was never opened (out-of-order) or go2rtc
+      // didn't give us a resource URL (no trickle support). Swallow.
+      this.logger.debug(
+        { event: 'publisher.ice_skipped', from: fromDashboardId },
+        'No WHEP resource — ignoring trickle candidate',
+      );
+      return;
+    }
+
+    try {
+      const res = await this.fetchImpl(session.resourceUrl, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/trickle-ice-sdpfrag' },
+        body: this.candidateToSdpFrag(candidate),
+      });
+      if (!res.ok && res.status !== 405) {
+        this.logger.warn(
+          { event: 'publisher.ice_patch_failed', from: fromDashboardId, status: res.status },
+          'WHEP PATCH for ICE candidate failed',
+        );
+      }
+    } catch (err) {
+      // Network error — swallow; the connection may still establish via
+      // the candidates already inline in the original SDP exchange.
+      this.logger.debug(
+        { event: 'publisher.ice_patch_error', from: fromDashboardId, error: String(err) },
+        'WHEP ICE PATCH errored',
+      );
+    }
+  }
+
+  async closeSession(fromDashboardId: string): Promise<void> {
+    const session = this.sessions.get(fromDashboardId);
+    if (!session) return;
+    this.sessions.delete(fromDashboardId);
+
+    if (!session.resourceUrl) return;
+    try {
+      await this.fetchImpl(session.resourceUrl, { method: 'DELETE' });
+    } catch {
+      // ignore — best-effort teardown
+    }
+    this.logger.info(
+      { event: 'publisher.session_closed', from: fromDashboardId },
+      'WHEP session closed',
+    );
+  }
+
+  async closeAllSessions(): Promise<void> {
+    const ids = Array.from(this.sessions.keys());
+    await Promise.all(ids.map((id) => this.closeSession(id)));
+  }
+
+  sessionCount(): number {
+    return this.sessions.size;
+  }
+
+  private candidateToSdpFrag(candidate: RTCIceCandidateInit): string {
+    // Minimal SDP fragment for WHEP trickle. Real impls are more
+    // elaborate, but go2rtc accepts the bare candidate line.
+    const cand = candidate.candidate ?? '';
+    const mid = candidate.sdpMid ?? '0';
+    return `a=mid:${mid}\r\na=${cand}\r\n`;
+  }
+}

--- a/apps/gateway/tests/unit/gateway-camera-publisher.test.ts
+++ b/apps/gateway/tests/unit/gateway-camera-publisher.test.ts
@@ -1,0 +1,242 @@
+import { GatewayCameraPublisher } from '../../src/infrastructure/webrtc/gateway-camera-publisher';
+
+const silentLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  child: jest.fn(),
+};
+
+const makeFetch = (impl: (req: { url: string; method: string; body?: string }) => Response | Promise<Response>) => {
+  const calls: Array<{ url: string; method: string; body?: string }> = [];
+  const fn = (async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const body = init?.body === undefined ? undefined : String(init.body);
+    const call = { url, method: init?.method ?? 'GET', body };
+    calls.push(call);
+    return impl(call);
+  }) as typeof fetch;
+  return { fn, calls };
+};
+
+const ok = (body = '', headers: Record<string, string> = {}): Response =>
+  new Response(body, { status: 200, headers });
+
+const created = (body: string, location: string): Response =>
+  new Response(body, { status: 201, headers: { location } });
+
+describe('GatewayCameraPublisher', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    silentLogger.child.mockReturnValue(silentLogger);
+  });
+
+  describe('handleViewerSignal — offer', () => {
+    it('POSTs SDP to WHEP and returns the answer', async () => {
+      const { fn, calls } = makeFetch(() => created('v=0\r\nanswer-sdp', '/api/webrtc/sess-1'));
+      const pub = new GatewayCameraPublisher({
+        cameraId: 'cam-1',
+        streamId: 'cam-1',
+        whepBaseUrl: 'http://127.0.0.1:1984/api/webrtc?src=cam-1',
+        fetchImpl: fn,
+        logger: silentLogger,
+      });
+
+      const result = await pub.handleViewerSignal('dash-1', {
+        type: 'offer',
+        sdp: 'v=0\r\noffer-sdp',
+      });
+
+      expect(result).toEqual({ type: 'answer', sdp: 'v=0\r\nanswer-sdp' });
+      expect(calls[0]!.method).toBe('POST');
+      expect(calls[0]!.body).toBe('v=0\r\noffer-sdp');
+      expect(pub.sessionCount()).toBe(1);
+    });
+
+    it('throws when WHEP rejects the offer', async () => {
+      const { fn } = makeFetch(() => new Response('bad', { status: 400 }));
+      const pub = new GatewayCameraPublisher({
+        cameraId: 'cam-1',
+        streamId: 'cam-1',
+        whepBaseUrl: 'http://127.0.0.1:1984/api/webrtc?src=cam-1',
+        fetchImpl: fn,
+        logger: silentLogger,
+      });
+      await expect(
+        pub.handleViewerSignal('dash-1', { type: 'offer', sdp: 'v=0' }),
+      ).rejects.toThrow(/HTTP 400/);
+      expect(pub.sessionCount()).toBe(0);
+    });
+
+    it('renegotiates by tearing down the previous session before opening a new one', async () => {
+      let callCount = 0;
+      const { fn, calls } = makeFetch(() => {
+        callCount++;
+        // First call: initial offer success. Second call: DELETE old session.
+        // Third call: new offer success.
+        if (callCount === 1) return created('v=0\r\nanswer-1', '/api/webrtc/sess-1');
+        if (callCount === 2) return ok();
+        return created('v=0\r\nanswer-2', '/api/webrtc/sess-2');
+      });
+      const pub = new GatewayCameraPublisher({
+        cameraId: 'cam-1',
+        streamId: 'cam-1',
+        whepBaseUrl: 'http://127.0.0.1:1984/api/webrtc?src=cam-1',
+        fetchImpl: fn,
+        logger: silentLogger,
+      });
+
+      await pub.handleViewerSignal('dash-1', { type: 'offer', sdp: 'v=0\r\noffer-1' });
+      await pub.handleViewerSignal('dash-1', { type: 'offer', sdp: 'v=0\r\noffer-2' });
+
+      expect(calls[0]!.method).toBe('POST');
+      expect(calls[1]!.method).toBe('DELETE');
+      expect(calls[2]!.method).toBe('POST');
+      expect(pub.sessionCount()).toBe(1);
+    });
+  });
+
+  describe('handleViewerSignal — ice-candidate', () => {
+    it('PATCHes the WHEP resource URL with the candidate', async () => {
+      let n = 0;
+      const { fn, calls } = makeFetch(() => {
+        n++;
+        if (n === 1) return created('v=0\r\nanswer', '/api/webrtc/sess-1');
+        return ok();
+      });
+      const pub = new GatewayCameraPublisher({
+        cameraId: 'cam-1',
+        streamId: 'cam-1',
+        whepBaseUrl: 'http://127.0.0.1:1984/api/webrtc?src=cam-1',
+        fetchImpl: fn,
+        logger: silentLogger,
+      });
+
+      await pub.handleViewerSignal('dash-1', { type: 'offer', sdp: 'v=0' });
+      const result = await pub.handleViewerSignal('dash-1', {
+        type: 'ice-candidate',
+        candidate: { candidate: 'candidate:1 1 udp 2113937151 192.168.0.5 54400 typ host', sdpMid: '0' },
+      });
+
+      expect(result).toBeNull();
+      expect(calls[1]!.method).toBe('PATCH');
+      expect(calls[1]!.url).toBe('/api/webrtc/sess-1');
+      expect(calls[1]!.body).toContain('a=mid:0');
+      expect(calls[1]!.body).toContain('candidate:1 1 udp');
+    });
+
+    it('swallows ICE candidate when no session exists yet', async () => {
+      const { fn, calls } = makeFetch(() => ok());
+      const pub = new GatewayCameraPublisher({
+        cameraId: 'cam-1',
+        streamId: 'cam-1',
+        whepBaseUrl: 'http://127.0.0.1:1984/api/webrtc?src=cam-1',
+        fetchImpl: fn,
+        logger: silentLogger,
+      });
+      const result = await pub.handleViewerSignal('dash-unknown', {
+        type: 'ice-candidate',
+        candidate: { candidate: 'candidate:1', sdpMid: '0' },
+      });
+      expect(result).toBeNull();
+      expect(calls).toHaveLength(0);
+    });
+
+    it('swallows PATCH failures (best-effort trickle)', async () => {
+      let n = 0;
+      const { fn } = makeFetch(() => {
+        n++;
+        if (n === 1) return created('v=0', '/api/webrtc/sess-1');
+        return new Response('', { status: 500 });
+      });
+      const pub = new GatewayCameraPublisher({
+        cameraId: 'cam-1',
+        streamId: 'cam-1',
+        whepBaseUrl: 'http://127.0.0.1:1984/api/webrtc?src=cam-1',
+        fetchImpl: fn,
+        logger: silentLogger,
+      });
+      await pub.handleViewerSignal('dash-1', { type: 'offer', sdp: 'v=0' });
+      await expect(
+        pub.handleViewerSignal('dash-1', {
+          type: 'ice-candidate',
+          candidate: { candidate: 'candidate:1', sdpMid: '0' },
+        }),
+      ).resolves.toBeNull();
+    });
+  });
+
+  describe('handleViewerSignal — answer', () => {
+    it('logs and returns null (gateway is the answerer side)', async () => {
+      const { fn } = makeFetch(() => ok());
+      const pub = new GatewayCameraPublisher({
+        cameraId: 'cam-1',
+        streamId: 'cam-1',
+        whepBaseUrl: 'http://127.0.0.1:1984/api/webrtc?src=cam-1',
+        fetchImpl: fn,
+        logger: silentLogger,
+      });
+      const result = await pub.handleViewerSignal('dash-1', { type: 'answer', sdp: 'v=0' });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('closeSession + closeAllSessions', () => {
+    it('DELETEs the WHEP resource', async () => {
+      let n = 0;
+      const { fn, calls } = makeFetch(() => {
+        n++;
+        if (n === 1) return created('v=0', '/api/webrtc/sess-1');
+        return ok();
+      });
+      const pub = new GatewayCameraPublisher({
+        cameraId: 'cam-1',
+        streamId: 'cam-1',
+        whepBaseUrl: 'http://127.0.0.1:1984/api/webrtc?src=cam-1',
+        fetchImpl: fn,
+        logger: silentLogger,
+      });
+      await pub.handleViewerSignal('dash-1', { type: 'offer', sdp: 'v=0' });
+      await pub.closeSession('dash-1');
+
+      expect(calls[1]!.method).toBe('DELETE');
+      expect(pub.sessionCount()).toBe(0);
+    });
+
+    it('closes all sessions in parallel', async () => {
+      let n = 0;
+      const { fn } = makeFetch(() => {
+        n++;
+        if (n <= 2) return created('v=0', `/api/webrtc/sess-${n}`);
+        return ok();
+      });
+      const pub = new GatewayCameraPublisher({
+        cameraId: 'cam-1',
+        streamId: 'cam-1',
+        whepBaseUrl: 'http://127.0.0.1:1984/api/webrtc?src=cam-1',
+        fetchImpl: fn,
+        logger: silentLogger,
+      });
+      await pub.handleViewerSignal('dash-1', { type: 'offer', sdp: 'v=0' });
+      await pub.handleViewerSignal('dash-2', { type: 'offer', sdp: 'v=0' });
+      expect(pub.sessionCount()).toBe(2);
+
+      await pub.closeAllSessions();
+      expect(pub.sessionCount()).toBe(0);
+    });
+
+    it('closeSession is a no-op for unknown session', async () => {
+      const { fn, calls } = makeFetch(() => ok());
+      const pub = new GatewayCameraPublisher({
+        cameraId: 'cam-1',
+        streamId: 'cam-1',
+        whepBaseUrl: 'http://127.0.0.1:1984/api/webrtc?src=cam-1',
+        fetchImpl: fn,
+        logger: silentLogger,
+      });
+      await pub.closeSession('ghost');
+      expect(calls).toHaveLength(0);
+    });
+  });
+});

--- a/apps/gateway/tests/unit/socketio-signaling.client.test.ts
+++ b/apps/gateway/tests/unit/socketio-signaling.client.test.ts
@@ -1,0 +1,173 @@
+import { SocketIoSignalingClient } from '../../src/infrastructure/signaling/socketio-signaling.client';
+
+const silentLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  child: jest.fn().mockReturnThis(),
+};
+
+class FakeSocket {
+  public id = 'sock-fake';
+  public connected = false;
+  public emitted: Array<{ event: string; payload: unknown }> = [];
+  public removedAll = false;
+  public disconnected = false;
+  private listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+  private onceListeners = new Map<string, Array<(...args: unknown[]) => void>>();
+
+  emit(event: string, payload: unknown): void {
+    this.emitted.push({ event, payload });
+  }
+  on(event: string, cb: (...args: unknown[]) => void): void {
+    const list = this.listeners.get(event) ?? [];
+    list.push(cb);
+    this.listeners.set(event, list);
+  }
+  once(event: string, cb: (...args: unknown[]) => void): void {
+    const list = this.onceListeners.get(event) ?? [];
+    list.push(cb);
+    this.onceListeners.set(event, list);
+  }
+  off(event: string, cb: (...args: unknown[]) => void): void {
+    const list = this.listeners.get(event) ?? [];
+    const idx = list.indexOf(cb);
+    if (idx >= 0) list.splice(idx, 1);
+    const onceList = this.onceListeners.get(event) ?? [];
+    const onceIdx = onceList.indexOf(cb);
+    if (onceIdx >= 0) onceList.splice(onceIdx, 1);
+  }
+  removeAllListeners(): void {
+    this.removedAll = true;
+    this.listeners.clear();
+    this.onceListeners.clear();
+  }
+  disconnect(): void {
+    this.disconnected = true;
+    this.connected = false;
+  }
+  fire(event: string, ...args: unknown[]): void {
+    for (const cb of this.listeners.get(event) ?? []) cb(...args);
+    for (const cb of this.onceListeners.get(event) ?? []) cb(...args);
+    this.onceListeners.set(event, []);
+  }
+}
+
+describe('SocketIoSignalingClient', () => {
+  let fakeSocket: FakeSocket;
+  let client: SocketIoSignalingClient;
+
+  beforeEach(() => {
+    fakeSocket = new FakeSocket();
+    silentLogger.child.mockReturnValue(silentLogger);
+    client = new SocketIoSignalingClient({
+      logger: silentLogger,
+      socketFactory: () => fakeSocket as unknown as Parameters<typeof Object>[0] as never,
+    });
+  });
+
+  describe('connect', () => {
+    it('resolves when socket emits connect', async () => {
+      const promise = client.connect('http://localhost:3010');
+      fakeSocket.fire('connect');
+      await expect(promise).resolves.toBeUndefined();
+    });
+
+    it('rejects when socket emits connect_error', async () => {
+      const promise = client.connect('http://localhost:3010');
+      fakeSocket.fire('connect_error', new Error('refused'));
+      await expect(promise).rejects.toThrow('refused');
+    });
+  });
+
+  describe('registerPresence', () => {
+    it('emits register-presence with role:camera', async () => {
+      const p = client.connect('http://x');
+      fakeSocket.fire('connect');
+      await p;
+
+      client.registerPresence('cam-1');
+      expect(fakeSocket.emitted).toContainEqual({
+        event: 'register-presence',
+        payload: { peerId: 'cam-1', role: 'camera' },
+      });
+    });
+
+    it('throws when called before connect', () => {
+      expect(() => client.registerPresence('cam-1')).toThrow(/not connected/);
+    });
+  });
+
+  describe('sendSignal', () => {
+    it('emits signal event with the payload', async () => {
+      const p = client.connect('http://x');
+      fakeSocket.fire('connect');
+      await p;
+
+      const dto = {
+        fromPeerId: 'cam-1',
+        toPeerId: 'dash-1',
+        payload: { type: 'answer' as const, sdp: 'v=0' },
+      };
+      client.sendSignal(dto);
+      expect(fakeSocket.emitted).toContainEqual({ event: 'signal', payload: dto });
+    });
+
+    it('drops the signal silently when not connected (logged at debug)', () => {
+      client.sendSignal({
+        fromPeerId: 'cam-1',
+        toPeerId: 'dash-1',
+        payload: { type: 'answer', sdp: 'v=0' },
+      });
+      expect(silentLogger.debug).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'signaling.send_dropped_no_socket' }),
+        expect.any(String),
+      );
+    });
+  });
+
+  describe('listeners', () => {
+    it('forwards signal events to onSignal handler', async () => {
+      const handler = jest.fn();
+      client.onSignal(handler);
+      const p = client.connect('http://x');
+      fakeSocket.fire('connect');
+      await p;
+
+      const dto = {
+        fromPeerId: 'dash-1',
+        toPeerId: 'cam-1',
+        payload: { type: 'offer' as const, sdp: 'v=0' },
+      };
+      fakeSocket.fire('signal', dto);
+      expect(handler).toHaveBeenCalledWith(dto);
+    });
+
+    it('forwards presence-change events to onPresenceChange handler', async () => {
+      const handler = jest.fn();
+      client.onPresenceChange(handler);
+      const p = client.connect('http://x');
+      fakeSocket.fire('connect');
+      await p;
+
+      fakeSocket.fire('presence-change', { peerId: 'dash-1', online: false });
+      expect(handler).toHaveBeenCalledWith({ peerId: 'dash-1', online: false });
+    });
+  });
+
+  describe('disconnect', () => {
+    it('removes listeners and disconnects the socket', async () => {
+      const p = client.connect('http://x');
+      fakeSocket.fire('connect');
+      await p;
+      await client.disconnect();
+      expect(fakeSocket.removedAll).toBe(true);
+      expect(fakeSocket.disconnected).toBe(true);
+    });
+
+    it('is a no-op when not connected', async () => {
+      await expect(client.disconnect()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/apps/gateway/tests/unit/start-camera.use-case.test.ts
+++ b/apps/gateway/tests/unit/start-camera.use-case.test.ts
@@ -1,0 +1,162 @@
+import { StartCameraUseCase } from '../../src/domain/use-cases/start-camera.use-case';
+import type { CameraConfig } from '../../src/domain/entities/camera-config.entity';
+import type { ICameraPublisher } from '../../src/domain/repositories/i-camera-publisher.repository';
+import type { ISignalingClient } from '../../src/domain/repositories/i-signaling.repository';
+import type { IGo2RtcClient } from '../../src/domain/repositories/i-go2rtc-client.repository';
+import type { PresenceChangeDto, SignalDto } from '@sentinel-monitor/shared-types';
+
+const camera: CameraConfig = {
+  id: 'cam-1',
+  label: 'Sala',
+  rtspUrl: 'rtsp://u:p@192.168.0.42:554/stream1',
+  addedAt: 1000,
+  pairedDashboards: ['dash-1'],
+};
+
+describe('StartCameraUseCase', () => {
+  let go2rtc: jest.Mocked<IGo2RtcClient>;
+  let signaling: jest.Mocked<ISignalingClient>;
+  let publisher: jest.Mocked<ICameraPublisher>;
+  let signalHandler: ((s: SignalDto) => void) | null;
+  let presenceHandler: ((e: PresenceChangeDto) => void) | null;
+
+  beforeEach(() => {
+    signalHandler = null;
+    presenceHandler = null;
+
+    go2rtc = {
+      health: jest.fn(),
+      registerStream: jest.fn().mockResolvedValue(undefined),
+      removeStream: jest.fn(),
+      getStreamHealth: jest.fn(),
+      getWhepUrl: jest.fn(),
+    };
+
+    signaling = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      disconnect: jest.fn(),
+      registerPresence: jest.fn(),
+      sendSignal: jest.fn(),
+      onSignal: jest.fn((handler) => {
+        signalHandler = handler;
+      }),
+      onPresenceChange: jest.fn((handler) => {
+        presenceHandler = handler;
+      }),
+    };
+
+    publisher = {
+      handleViewerSignal: jest.fn(),
+      closeSession: jest.fn().mockResolvedValue(undefined),
+      closeAllSessions: jest.fn(),
+      sessionCount: jest.fn(),
+    };
+  });
+
+  it('registers the RTSP source, connects signaling, and announces presence', async () => {
+    const useCase = new StartCameraUseCase({ signaling, publisher, go2rtc });
+    const result = await useCase.execute({
+      camera,
+      signalingUrl: 'http://localhost:3010',
+    });
+
+    expect(result).toEqual({ started: true });
+    expect(go2rtc.registerStream).toHaveBeenCalledWith(camera.id, camera.rtspUrl);
+    expect(signaling.connect).toHaveBeenCalledWith('http://localhost:3010');
+    expect(signaling.registerPresence).toHaveBeenCalledWith(camera.id);
+  });
+
+  it('returns started:false when go2rtc registration fails', async () => {
+    go2rtc.registerStream.mockRejectedValue(new Error('connection refused'));
+    const useCase = new StartCameraUseCase({ signaling, publisher, go2rtc });
+
+    const result = await useCase.execute({ camera, signalingUrl: 'http://x' });
+    expect(result).toEqual({
+      started: false,
+      reason: 'go2rtc.registerStream failed: connection refused',
+    });
+    expect(signaling.connect).not.toHaveBeenCalled();
+  });
+
+  it('returns started:false when signaling connect fails', async () => {
+    signaling.connect.mockRejectedValue(new Error('timeout'));
+    const useCase = new StartCameraUseCase({ signaling, publisher, go2rtc });
+
+    const result = await useCase.execute({ camera, signalingUrl: 'http://x' });
+    expect(result.started).toBe(false);
+    if (!result.started) expect(result.reason).toMatch(/signaling.connect/);
+  });
+
+  describe('signal forwarding', () => {
+    it('forwards offers addressed to this camera to the publisher and replies via signaling', async () => {
+      publisher.handleViewerSignal.mockResolvedValue({ type: 'answer', sdp: 'v=0\r\nans' });
+      const useCase = new StartCameraUseCase({ signaling, publisher, go2rtc });
+      await useCase.execute({ camera, signalingUrl: 'http://x' });
+
+      const offer: SignalDto = {
+        fromPeerId: 'dash-1',
+        toPeerId: 'cam-1',
+        payload: { type: 'offer', sdp: 'v=0\r\noff' },
+      };
+      await signalHandler!(offer);
+
+      expect(publisher.handleViewerSignal).toHaveBeenCalledWith('dash-1', offer.payload);
+      expect(signaling.sendSignal).toHaveBeenCalledWith({
+        fromPeerId: 'cam-1',
+        toPeerId: 'dash-1',
+        payload: { type: 'answer', sdp: 'v=0\r\nans' },
+      });
+    });
+
+    it('does not reply when publisher returns null (e.g., trickle ICE)', async () => {
+      publisher.handleViewerSignal.mockResolvedValue(null);
+      const useCase = new StartCameraUseCase({ signaling, publisher, go2rtc });
+      await useCase.execute({ camera, signalingUrl: 'http://x' });
+
+      await signalHandler!({
+        fromPeerId: 'dash-1',
+        toPeerId: 'cam-1',
+        payload: { type: 'ice-candidate', candidate: { candidate: 'x', sdpMid: '0' } },
+      });
+
+      expect(publisher.handleViewerSignal).toHaveBeenCalled();
+      expect(signaling.sendSignal).not.toHaveBeenCalled();
+    });
+
+    it('ignores signals addressed to other peers', async () => {
+      const useCase = new StartCameraUseCase({ signaling, publisher, go2rtc });
+      await useCase.execute({ camera, signalingUrl: 'http://x' });
+
+      await signalHandler!({
+        fromPeerId: 'dash-1',
+        toPeerId: 'other-camera',
+        payload: { type: 'offer', sdp: 'v=0' },
+      });
+
+      expect(publisher.handleViewerSignal).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('presence handling', () => {
+    it('closes a dashboard session when its presence drops', async () => {
+      const useCase = new StartCameraUseCase({ signaling, publisher, go2rtc });
+      await useCase.execute({ camera, signalingUrl: 'http://x' });
+
+      presenceHandler!({ peerId: 'dash-1', online: false });
+      // Allow microtasks to resolve.
+      await new Promise((r) => setImmediate(r));
+
+      expect(publisher.closeSession).toHaveBeenCalledWith('dash-1');
+    });
+
+    it('does nothing when a dashboard comes online (peer initiates the offer)', async () => {
+      const useCase = new StartCameraUseCase({ signaling, publisher, go2rtc });
+      await useCase.execute({ camera, signalingUrl: 'http://x' });
+
+      presenceHandler!({ peerId: 'dash-1', online: true });
+      await new Promise((r) => setImmediate(r));
+
+      expect(publisher.closeSession).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/gateway/tests/unit/stop-camera.use-case.test.ts
+++ b/apps/gateway/tests/unit/stop-camera.use-case.test.ts
@@ -1,0 +1,51 @@
+import { StopCameraUseCase } from '../../src/domain/use-cases/stop-camera.use-case';
+import type { ICameraPublisher } from '../../src/domain/repositories/i-camera-publisher.repository';
+import type { ISignalingClient } from '../../src/domain/repositories/i-signaling.repository';
+import type { IGo2RtcClient } from '../../src/domain/repositories/i-go2rtc-client.repository';
+
+describe('StopCameraUseCase', () => {
+  let go2rtc: jest.Mocked<IGo2RtcClient>;
+  let signaling: jest.Mocked<ISignalingClient>;
+  let publisher: jest.Mocked<ICameraPublisher>;
+
+  beforeEach(() => {
+    go2rtc = {
+      health: jest.fn(),
+      registerStream: jest.fn(),
+      removeStream: jest.fn().mockResolvedValue(undefined),
+      getStreamHealth: jest.fn(),
+      getWhepUrl: jest.fn(),
+    };
+    signaling = {
+      connect: jest.fn(),
+      disconnect: jest.fn().mockResolvedValue(undefined),
+      registerPresence: jest.fn(),
+      sendSignal: jest.fn(),
+      onSignal: jest.fn(),
+      onPresenceChange: jest.fn(),
+    };
+    publisher = {
+      handleViewerSignal: jest.fn(),
+      closeSession: jest.fn(),
+      closeAllSessions: jest.fn().mockResolvedValue(undefined),
+      sessionCount: jest.fn(),
+    };
+  });
+
+  it('closes all sessions, disconnects signaling, and removes the go2rtc stream', async () => {
+    const useCase = new StopCameraUseCase({ signaling, publisher, go2rtc });
+    await useCase.execute({ cameraId: 'cam-1' });
+
+    expect(publisher.closeAllSessions).toHaveBeenCalled();
+    expect(signaling.disconnect).toHaveBeenCalled();
+    expect(go2rtc.removeStream).toHaveBeenCalledWith('cam-1');
+  });
+
+  it('still completes when go2rtc.removeStream throws (best-effort)', async () => {
+    go2rtc.removeStream.mockRejectedValue(new Error('go2rtc gone'));
+    const useCase = new StopCameraUseCase({ signaling, publisher, go2rtc });
+    await expect(useCase.execute({ cameraId: 'cam-1' })).resolves.toBeUndefined();
+    expect(publisher.closeAllSessions).toHaveBeenCalled();
+    expect(signaling.disconnect).toHaveBeenCalled();
+  });
+});

--- a/apps/gateway/tsconfig.json
+++ b/apps/gateway/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "types": ["node", "jest"]
   },
   "include": ["src", "tests"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,9 @@ importers:
       pino:
         specifier: ^9.5.0
         version: 9.14.0
+      socket.io-client:
+        specifier: ^4.8.0
+        version: 4.8.3
       yaml:
         specifier: ^2.6.0
         version: 2.8.4


### PR DESCRIPTION
Closes #33

PR-G3. Gateway connects as N peer cameras (one per configured camera) and proxies SDP between viewers and go2rtc via WHEP. **No RTCPeerConnection in gateway** — go2rtc holds the actual peers, keeping this portable to ARM/Pi.

## Delivered
- `ISignalingClient` + `ICameraPublisher` interfaces
- `SocketIoSignalingClient` (typed, reconnect-aware)
- `GatewayCameraPublisher` (WHEP proxy: POST offer, PATCH ICE best-effort, DELETE teardown, renegotiation)
- `StartCameraUseCase` + `StopCameraUseCase`
- 30 new tests (62 total), coverage 92-97%

## Out of scope
- PR-G4 #34: pairing flow + binding writeback
- PR-G5 #35: docker-compose + smoke test