### PR TITLE
feat(gateway): pairing flow + binding writeback + HTTP inspector

### DIFF
--- a/apps/gateway/src/domain/repositories/i-signaling.repository.ts
+++ b/apps/gateway/src/domain/repositories/i-signaling.repository.ts
@@ -1,4 +1,8 @@
-import type { SignalDto } from '@sentinel-monitor/shared-types';
+import type {
+  PairingCodeIssuedDto,
+  PairingRedeemedDto,
+  SignalDto,
+} from '@sentinel-monitor/shared-types';
 
 // Gateway-side signaling client. Each camera owns one connection (one
 // `peerId = cameraId`) and listens for inbound signals + presence
@@ -24,4 +28,10 @@ export interface ISignalingClient {
   onPresenceChange(
     handler: (event: { peerId: string; online: boolean }) => void,
   ): void;
+
+  /** Request a fresh pairing code for this camera. Resolves with the code + expiry. */
+  requestPairingCode(cameraId: string): Promise<PairingCodeIssuedDto>;
+
+  /** Subscribe to pairing-redeemed pushes (operator entered our code at the dashboard). */
+  onPairingRedeemed(handler: (event: PairingRedeemedDto) => void): void;
 }

--- a/apps/gateway/src/domain/use-cases/handle-pairing-redeemed.use-case.ts
+++ b/apps/gateway/src/domain/use-cases/handle-pairing-redeemed.use-case.ts
@@ -1,0 +1,87 @@
+import type { GatewayConfig } from '../entities/gateway-config.entity';
+import type { CameraConfig } from '../entities/camera-config.entity';
+import type { IConfigStorageRepository } from '../repositories/i-config-storage.repository';
+import type { ILogger } from '../../infrastructure/logging/logger';
+import type { PairingRedeemedDto } from '@sentinel-monitor/shared-types';
+
+export interface HandlePairingRedeemedDeps {
+  readonly configStorage: IConfigStorageRepository;
+  readonly logger: ILogger;
+}
+
+export type HandlePairingRedeemedResult =
+  | { readonly handled: true; readonly cameraId: string; readonly dashboardId: string; readonly alreadyPaired: boolean }
+  | { readonly handled: false; readonly reason: 'unknown-camera' };
+
+/**
+ * When the signaling server pushes pairing-redeemed{cameraId, dashboardId}:
+ * appends the dashboardId to that camera's pairedDashboards list and
+ * persists the config back to disk so the binding survives restarts.
+ *
+ * Idempotent: redeeming the same pair twice is a no-op (alreadyPaired:true).
+ */
+export class HandlePairingRedeemedUseCase {
+  constructor(private readonly deps: HandlePairingRedeemedDeps) {}
+
+  async execute(event: PairingRedeemedDto): Promise<HandlePairingRedeemedResult> {
+    const config = await this.deps.configStorage.load();
+    const camera = config.cameras.find((c) => c.id === event.cameraId);
+
+    if (!camera) {
+      this.deps.logger.warn(
+        { event: 'pairing.redeemed_unknown_camera', cameraId: event.cameraId },
+        'pairing-redeemed referenced an unknown camera id',
+      );
+      return { handled: false, reason: 'unknown-camera' };
+    }
+
+    if (camera.pairedDashboards.includes(event.dashboardId)) {
+      this.deps.logger.debug(
+        {
+          event: 'pairing.redeemed_already_paired',
+          cameraId: event.cameraId,
+          dashboardId: event.dashboardId,
+        },
+        'pairing-redeemed for an already-paired dashboard; ignoring',
+      );
+      return {
+        handled: true,
+        cameraId: event.cameraId,
+        dashboardId: event.dashboardId,
+        alreadyPaired: true,
+      };
+    }
+
+    const next: GatewayConfig = {
+      ...config,
+      cameras: config.cameras.map((c): CameraConfig =>
+        c.id === event.cameraId
+          ? {
+              ...c,
+              pairedDashboards: [...c.pairedDashboards, event.dashboardId],
+            }
+          : c,
+      ),
+    };
+
+    await this.deps.configStorage.save(next);
+
+    this.deps.logger.info(
+      {
+        event: 'pairing.redeemed',
+        cameraId: event.cameraId,
+        cameraLabel: camera.label,
+        dashboardId: event.dashboardId,
+        pairedCount: next.cameras.find((c) => c.id === event.cameraId)?.pairedDashboards.length,
+      },
+      `Camera "${camera.label}" paired with a new dashboard`,
+    );
+
+    return {
+      handled: true,
+      cameraId: event.cameraId,
+      dashboardId: event.dashboardId,
+      alreadyPaired: false,
+    };
+  }
+}

--- a/apps/gateway/src/domain/use-cases/request-pairing.use-case.ts
+++ b/apps/gateway/src/domain/use-cases/request-pairing.use-case.ts
@@ -1,0 +1,75 @@
+import type { CameraConfig } from '../entities/camera-config.entity';
+import type { ISignalingClient } from '../repositories/i-signaling.repository';
+import type { ILogger } from '../../infrastructure/logging/logger';
+
+export interface RequestPairingDeps {
+  readonly signaling: ISignalingClient;
+  readonly logger: ILogger;
+  readonly maxRetries?: number;
+}
+
+export interface PairingPrompt {
+  readonly cameraId: string;
+  readonly label: string;
+  readonly code: string;
+  readonly expiresAt: number;
+}
+
+const DEFAULT_MAX_RETRIES = 3;
+
+/**
+ * Asks the signaling server for a fresh pairing code for one camera and
+ * returns it for display (logs + HTTP /pairing inspector). Retries up
+ * to `maxRetries` on transient failures, then surfaces the error so the
+ * caller can decide whether to give up.
+ */
+export class RequestPairingUseCase {
+  constructor(private readonly deps: RequestPairingDeps) {}
+
+  async execute(camera: CameraConfig): Promise<PairingPrompt> {
+    const max = this.deps.maxRetries ?? DEFAULT_MAX_RETRIES;
+    let lastErr: unknown;
+
+    for (let attempt = 1; attempt <= max; attempt++) {
+      try {
+        const issued = await this.deps.signaling.requestPairingCode(camera.id);
+        this.deps.logger.info(
+          {
+            event: 'pairing.code_issued',
+            cameraId: camera.id,
+            cameraLabel: camera.label,
+            code: issued.code,
+            expiresAt: issued.expiresAt,
+          },
+          `Pairing code for "${camera.label}": ${issued.code}`,
+        );
+        return {
+          cameraId: camera.id,
+          label: camera.label,
+          code: issued.code,
+          expiresAt: issued.expiresAt,
+        };
+      } catch (err) {
+        lastErr = err;
+        this.deps.logger.warn(
+          {
+            event: 'pairing.request_failed',
+            cameraId: camera.id,
+            attempt,
+            maxRetries: max,
+            error: err instanceof Error ? err.message : String(err),
+          },
+          'Pairing-code request failed; will retry',
+        );
+      }
+    }
+
+    this.deps.logger.error(
+      { event: 'pairing.request_exhausted', cameraId: camera.id, maxRetries: max },
+      `Pairing-code request gave up after ${max} attempts`,
+    );
+    throw lastErr instanceof Error
+      ? lastErr
+      : new Error(`Pairing-code request gave up after ${max} attempts`);
+  }
+}

--- a/apps/gateway/src/infrastructure/signaling/socketio-signaling.client.ts
+++ b/apps/gateway/src/infrastructure/signaling/socketio-signaling.client.ts
@@ -2,6 +2,8 @@ import { io, type Socket } from 'socket.io-client';
 import type {
   IClientToServerEvents,
   IServerToClientEvents,
+  PairingCodeIssuedDto,
+  PairingRedeemedDto,
   PresenceChangeDto,
   SignalDto,
 } from '@sentinel-monitor/shared-types';
@@ -21,6 +23,7 @@ export class SocketIoSignalingClient implements ISignalingClient {
   private readonly socketFactory: (url: string) => TypedSocket;
   private signalHandler: ((p: SignalDto) => void) | null = null;
   private presenceHandler: ((e: PresenceChangeDto) => void) | null = null;
+  private pairingRedeemedHandler: ((e: PairingRedeemedDto) => void) | null = null;
 
   constructor(opts: SocketIoSignalingClientOptions) {
     this.logger = opts.logger;
@@ -62,6 +65,10 @@ export class SocketIoSignalingClient implements ISignalingClient {
 
     this.socket.on('presence-change', (event: PresenceChangeDto) => {
       this.presenceHandler?.(event);
+    });
+
+    this.socket.on('pairing-redeemed', (event: PairingRedeemedDto) => {
+      this.pairingRedeemedHandler?.(event);
     });
 
     return new Promise<void>((resolve, reject) => {
@@ -114,5 +121,20 @@ export class SocketIoSignalingClient implements ISignalingClient {
 
   onPresenceChange(handler: (event: PresenceChangeDto) => void): void {
     this.presenceHandler = handler;
+  }
+
+  requestPairingCode(cameraId: string): Promise<PairingCodeIssuedDto> {
+    if (!this.socket) {
+      return Promise.reject(new Error('requestPairingCode: signaling not connected'));
+    }
+    return new Promise((resolve) => {
+      this.socket!.emit('request-pairing-code', { cameraId }, (response) => {
+        resolve(response);
+      });
+    });
+  }
+
+  onPairingRedeemed(handler: (event: PairingRedeemedDto) => void): void {
+    this.pairingRedeemedHandler = handler;
   }
 }

--- a/apps/gateway/src/presentation/http/pairing-status.handler.ts
+++ b/apps/gateway/src/presentation/http/pairing-status.handler.ts
@@ -1,0 +1,133 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { ILogger } from '../../infrastructure/logging/logger';
+import type { PairingPrompt } from '../../domain/use-cases/request-pairing.use-case';
+import type { GatewayConfig } from '../../domain/entities/gateway-config.entity';
+
+export interface PairingStatusHandlerOptions {
+  readonly logger: ILogger;
+  readonly port?: number;
+}
+
+interface PairingSnapshot {
+  readonly id: string;
+  readonly label: string;
+  readonly pairedDashboards: readonly string[];
+  readonly currentCode?: { code: string; expiresAt: number };
+}
+
+const DEFAULT_PORT = 9090;
+
+/**
+ * Tiny HTTP server (no Express) on localhost:9090 that exposes the
+ * gateway's pairing status as JSON. Operator can `curl localhost:9090/pairing`
+ * to see active pairing codes, dashboards already bound, etc.
+ *
+ * Designed for LAN diagnostics only — binds to 127.0.0.1, not 0.0.0.0.
+ */
+export class PairingStatusHandler {
+  private server: Server | null = null;
+  private readonly logger: ILogger;
+  private readonly port: number;
+  private snapshot: { config: GatewayConfig | null; prompts: Map<string, PairingPrompt> } = {
+    config: null,
+    prompts: new Map(),
+  };
+
+  constructor(opts: PairingStatusHandlerOptions) {
+    this.logger = opts.logger;
+    this.port = opts.port ?? DEFAULT_PORT;
+  }
+
+  setConfig(config: GatewayConfig): void {
+    this.snapshot.config = config;
+  }
+
+  setPrompt(prompt: PairingPrompt): void {
+    this.snapshot.prompts.set(prompt.cameraId, prompt);
+  }
+
+  clearPrompt(cameraId: string): void {
+    this.snapshot.prompts.delete(cameraId);
+  }
+
+  async start(): Promise<void> {
+    if (this.server) return;
+
+    this.server = createServer((req, res) => this.handleRequest(req, res));
+
+    return new Promise<void>((resolve, reject) => {
+      const server = this.server!;
+      server.once('error', reject);
+      server.listen(this.port, '127.0.0.1', () => {
+        server.off('error', reject);
+        this.logger.info(
+          { event: 'pairing.http_started', port: this.port },
+          `Pairing inspector at http://127.0.0.1:${this.port}/pairing`,
+        );
+        resolve();
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (!this.server) return;
+    return new Promise<void>((resolve) => {
+      this.server!.close(() => {
+        this.server = null;
+        resolve();
+      });
+    });
+  }
+
+  private handleRequest(req: IncomingMessage, res: ServerResponse): void {
+    if (!req.url || !req.method) {
+      res.writeHead(400);
+      res.end();
+      return;
+    }
+
+    if (req.method !== 'GET') {
+      res.writeHead(405, { Allow: 'GET' });
+      res.end();
+      return;
+    }
+
+    if (req.url === '/pairing') {
+      this.respondWithSnapshot(res);
+      return;
+    }
+
+    if (req.url === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok' }));
+      return;
+    }
+
+    res.writeHead(404);
+    res.end();
+  }
+
+  private respondWithSnapshot(res: ServerResponse): void {
+    const config = this.snapshot.config;
+    if (!config) {
+      res.writeHead(503, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'gateway not yet ready' }));
+      return;
+    }
+
+    const cameras: PairingSnapshot[] = config.cameras.map((cam) => {
+      const prompt = this.snapshot.prompts.get(cam.id);
+      return {
+        id: cam.id,
+        label: cam.label,
+        pairedDashboards: cam.pairedDashboards,
+        ...(prompt
+          ? { currentCode: { code: prompt.code, expiresAt: prompt.expiresAt } }
+          : {}),
+      };
+    });
+
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ gatewayId: config.id, cameras }, null, 2));
+  }
+}

--- a/apps/gateway/tests/unit/handle-pairing-redeemed.use-case.test.ts
+++ b/apps/gateway/tests/unit/handle-pairing-redeemed.use-case.test.ts
@@ -1,0 +1,143 @@
+import { HandlePairingRedeemedUseCase } from '../../src/domain/use-cases/handle-pairing-redeemed.use-case';
+import type { IConfigStorageRepository } from '../../src/domain/repositories/i-config-storage.repository';
+import type { GatewayConfig } from '../../src/domain/entities/gateway-config.entity';
+
+const baseConfig = (cameras: GatewayConfig['cameras']): GatewayConfig => ({
+  id: '11111111-1111-1111-1111-111111111111',
+  signalingUrl: 'http://localhost:3010',
+  go2rtcUrl: 'http://127.0.0.1:1984',
+  cameras,
+});
+
+const silentLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  child: jest.fn().mockReturnThis(),
+};
+
+describe('HandlePairingRedeemedUseCase', () => {
+  let storage: jest.Mocked<IConfigStorageRepository>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    silentLogger.child.mockReturnValue(silentLogger);
+    storage = {
+      load: jest.fn(),
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  it('appends a new dashboardId to the camera and persists', async () => {
+    storage.load.mockResolvedValue(
+      baseConfig([
+        {
+          id: 'cam-1',
+          label: 'Sala',
+          rtspUrl: 'rtsp://u:p@host:554/s1',
+          addedAt: 1000,
+          pairedDashboards: [],
+        },
+      ]),
+    );
+
+    const useCase = new HandlePairingRedeemedUseCase({
+      configStorage: storage,
+      logger: silentLogger,
+    });
+    const result = await useCase.execute({ cameraId: 'cam-1', dashboardId: 'dash-1' });
+
+    expect(result).toEqual({
+      handled: true,
+      cameraId: 'cam-1',
+      dashboardId: 'dash-1',
+      alreadyPaired: false,
+    });
+    expect(storage.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cameras: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'cam-1',
+            pairedDashboards: ['dash-1'],
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it('is idempotent for an already-paired dashboard (no save)', async () => {
+    storage.load.mockResolvedValue(
+      baseConfig([
+        {
+          id: 'cam-1',
+          label: 'Sala',
+          rtspUrl: 'rtsp://u:p@host:554/s1',
+          addedAt: 1000,
+          pairedDashboards: ['dash-1'],
+        },
+      ]),
+    );
+
+    const useCase = new HandlePairingRedeemedUseCase({
+      configStorage: storage,
+      logger: silentLogger,
+    });
+    const result = await useCase.execute({ cameraId: 'cam-1', dashboardId: 'dash-1' });
+
+    expect(result).toEqual({
+      handled: true,
+      cameraId: 'cam-1',
+      dashboardId: 'dash-1',
+      alreadyPaired: true,
+    });
+    expect(storage.save).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown camera ids without saving', async () => {
+    storage.load.mockResolvedValue(baseConfig([]));
+
+    const useCase = new HandlePairingRedeemedUseCase({
+      configStorage: storage,
+      logger: silentLogger,
+    });
+    const result = await useCase.execute({ cameraId: 'ghost', dashboardId: 'dash-1' });
+
+    expect(result).toEqual({ handled: false, reason: 'unknown-camera' });
+    expect(storage.save).not.toHaveBeenCalled();
+  });
+
+  it('preserves other cameras and previously-paired dashboards', async () => {
+    storage.load.mockResolvedValue(
+      baseConfig([
+        {
+          id: 'cam-1',
+          label: 'Sala',
+          rtspUrl: 'rtsp://u:p@host:554/s1',
+          addedAt: 1000,
+          pairedDashboards: ['dash-old'],
+        },
+        {
+          id: 'cam-2',
+          label: 'Quarto',
+          rtspUrl: 'rtsp://u:p@host2:554/s1',
+          addedAt: 1001,
+          pairedDashboards: [],
+        },
+      ]),
+    );
+
+    const useCase = new HandlePairingRedeemedUseCase({
+      configStorage: storage,
+      logger: silentLogger,
+    });
+    await useCase.execute({ cameraId: 'cam-1', dashboardId: 'dash-new' });
+
+    const saved = storage.save.mock.calls[0]![0];
+    expect(saved.cameras).toHaveLength(2);
+    const cam1 = saved.cameras.find((c) => c.id === 'cam-1')!;
+    const cam2 = saved.cameras.find((c) => c.id === 'cam-2')!;
+    expect(cam1.pairedDashboards).toEqual(['dash-old', 'dash-new']);
+    expect(cam2.pairedDashboards).toEqual([]);
+  });
+});

--- a/apps/gateway/tests/unit/pairing-status.handler.test.ts
+++ b/apps/gateway/tests/unit/pairing-status.handler.test.ts
@@ -1,0 +1,131 @@
+import { PairingStatusHandler } from '../../src/presentation/http/pairing-status.handler';
+import type { GatewayConfig } from '../../src/domain/entities/gateway-config.entity';
+
+const silentLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  child: jest.fn().mockReturnThis(),
+};
+
+const baseConfig = (): GatewayConfig => ({
+  id: '11111111-1111-1111-1111-111111111111',
+  signalingUrl: 'http://localhost:3010',
+  go2rtcUrl: 'http://127.0.0.1:1984',
+  cameras: [
+    {
+      id: 'cam-1',
+      label: 'Sala',
+      rtspUrl: 'rtsp://u:p@host:554/s1',
+      addedAt: 1000,
+      pairedDashboards: ['dash-old'],
+    },
+  ],
+});
+
+let port: number;
+
+const fetchPath = async (path: string): Promise<{ status: number; body: string }> => {
+  const res = await fetch(`http://127.0.0.1:${port}${path}`);
+  return { status: res.status, body: await res.text() };
+};
+
+describe('PairingStatusHandler', () => {
+  let handler: PairingStatusHandler;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    silentLogger.child.mockReturnValue(silentLogger);
+    port = 9000 + Math.floor(Math.random() * 800);
+    handler = new PairingStatusHandler({ logger: silentLogger, port });
+    await handler.start();
+  });
+
+  afterEach(async () => {
+    await handler.stop();
+  });
+
+  describe('GET /pairing', () => {
+    it('returns 503 before config is set', async () => {
+      const res = await fetchPath('/pairing');
+      expect(res.status).toBe(503);
+    });
+
+    it('returns gateway + cameras + paired dashboards once config is set', async () => {
+      handler.setConfig(baseConfig());
+      const res = await fetchPath('/pairing');
+
+      expect(res.status).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.gatewayId).toBe('11111111-1111-1111-1111-111111111111');
+      expect(body.cameras).toHaveLength(1);
+      expect(body.cameras[0].id).toBe('cam-1');
+      expect(body.cameras[0].pairedDashboards).toEqual(['dash-old']);
+      expect(body.cameras[0].currentCode).toBeUndefined();
+    });
+
+    it('includes currentCode for cameras with active prompts', async () => {
+      handler.setConfig(baseConfig());
+      handler.setPrompt({
+        cameraId: 'cam-1',
+        label: 'Sala',
+        code: 'ABC123',
+        expiresAt: 1700000060000,
+      });
+
+      const res = await fetchPath('/pairing');
+      const body = JSON.parse(res.body);
+      expect(body.cameras[0].currentCode).toEqual({
+        code: 'ABC123',
+        expiresAt: 1700000060000,
+      });
+    });
+
+    it('clears prompt when clearPrompt is called', async () => {
+      handler.setConfig(baseConfig());
+      handler.setPrompt({
+        cameraId: 'cam-1',
+        label: 'Sala',
+        code: 'ABC123',
+        expiresAt: 1700000060000,
+      });
+      handler.clearPrompt('cam-1');
+
+      const res = await fetchPath('/pairing');
+      const body = JSON.parse(res.body);
+      expect(body.cameras[0].currentCode).toBeUndefined();
+    });
+  });
+
+  describe('GET /health', () => {
+    it('returns 200 ok', async () => {
+      const res = await fetchPath('/health');
+      expect(res.status).toBe(200);
+      expect(JSON.parse(res.body)).toEqual({ status: 'ok' });
+    });
+  });
+
+  describe('other methods + paths', () => {
+    it('rejects POST with 405', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/pairing`, { method: 'POST' });
+      expect(res.status).toBe(405);
+    });
+
+    it('returns 404 for unknown paths', async () => {
+      const res = await fetchPath('/whatever');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('start() is idempotent', async () => {
+      await expect(handler.start()).resolves.toBeUndefined();
+    });
+
+    it('stop() is idempotent', async () => {
+      await handler.stop();
+      await expect(handler.stop()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/apps/gateway/tests/unit/request-pairing.use-case.test.ts
+++ b/apps/gateway/tests/unit/request-pairing.use-case.test.ts
@@ -1,0 +1,110 @@
+import { RequestPairingUseCase } from '../../src/domain/use-cases/request-pairing.use-case';
+import type { ISignalingClient } from '../../src/domain/repositories/i-signaling.repository';
+import type { CameraConfig } from '../../src/domain/entities/camera-config.entity';
+
+const camera: CameraConfig = {
+  id: 'cam-1',
+  label: 'Sala',
+  rtspUrl: 'rtsp://u:p@192.168.0.42:554/stream1',
+  addedAt: 1000,
+  pairedDashboards: [],
+};
+
+const silentLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  child: jest.fn().mockReturnThis(),
+};
+
+describe('RequestPairingUseCase', () => {
+  let signaling: jest.Mocked<ISignalingClient>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    silentLogger.child.mockReturnValue(silentLogger);
+    signaling = {
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+      registerPresence: jest.fn(),
+      sendSignal: jest.fn(),
+      onSignal: jest.fn(),
+      onPresenceChange: jest.fn(),
+      requestPairingCode: jest.fn(),
+      onPairingRedeemed: jest.fn(),
+    };
+  });
+
+  it('returns the issued code on first attempt success', async () => {
+    signaling.requestPairingCode.mockResolvedValue({ code: 'ABC123', expiresAt: 1700000060000 });
+
+    const useCase = new RequestPairingUseCase({ signaling, logger: silentLogger });
+    const prompt = await useCase.execute(camera);
+
+    expect(prompt).toEqual({
+      cameraId: 'cam-1',
+      label: 'Sala',
+      code: 'ABC123',
+      expiresAt: 1700000060000,
+    });
+    expect(signaling.requestPairingCode).toHaveBeenCalledTimes(1);
+    expect(silentLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'pairing.code_issued', code: 'ABC123' }),
+      expect.any(String),
+    );
+  });
+
+  it('retries up to maxRetries before giving up', async () => {
+    signaling.requestPairingCode
+      .mockRejectedValueOnce(new Error('transient 1'))
+      .mockRejectedValueOnce(new Error('transient 2'))
+      .mockResolvedValueOnce({ code: 'XYZ789', expiresAt: 1700000060000 });
+
+    const useCase = new RequestPairingUseCase({
+      signaling,
+      logger: silentLogger,
+      maxRetries: 3,
+    });
+    const prompt = await useCase.execute(camera);
+
+    expect(prompt.code).toBe('XYZ789');
+    expect(signaling.requestPairingCode).toHaveBeenCalledTimes(3);
+    expect(silentLogger.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws after exhausting all retries', async () => {
+    signaling.requestPairingCode.mockRejectedValue(new Error('always fails'));
+
+    const useCase = new RequestPairingUseCase({
+      signaling,
+      logger: silentLogger,
+      maxRetries: 2,
+    });
+    await expect(useCase.execute(camera)).rejects.toThrow('always fails');
+    expect(signaling.requestPairingCode).toHaveBeenCalledTimes(2);
+    expect(silentLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'pairing.request_exhausted' }),
+      expect.any(String),
+    );
+  });
+
+  it('uses default 3 retries when not specified', async () => {
+    signaling.requestPairingCode.mockRejectedValue(new Error('boom'));
+
+    const useCase = new RequestPairingUseCase({ signaling, logger: silentLogger });
+    await expect(useCase.execute(camera)).rejects.toThrow('boom');
+    expect(signaling.requestPairingCode).toHaveBeenCalledTimes(3);
+  });
+
+  it('wraps non-Error rejections in Error', async () => {
+    signaling.requestPairingCode.mockRejectedValue('string error');
+
+    const useCase = new RequestPairingUseCase({
+      signaling,
+      logger: silentLogger,
+      maxRetries: 1,
+    });
+    await expect(useCase.execute(camera)).rejects.toBeInstanceOf(Error);
+  });
+});

--- a/apps/gateway/tests/unit/start-camera.use-case.test.ts
+++ b/apps/gateway/tests/unit/start-camera.use-case.test.ts
@@ -43,6 +43,8 @@ describe('StartCameraUseCase', () => {
       onPresenceChange: jest.fn((handler) => {
         presenceHandler = handler;
       }),
+      requestPairingCode: jest.fn(),
+      onPairingRedeemed: jest.fn(),
     };
 
     publisher = {

--- a/apps/gateway/tests/unit/stop-camera.use-case.test.ts
+++ b/apps/gateway/tests/unit/stop-camera.use-case.test.ts
@@ -23,6 +23,8 @@ describe('StopCameraUseCase', () => {
       sendSignal: jest.fn(),
       onSignal: jest.fn(),
       onPresenceChange: jest.fn(),
+      requestPairingCode: jest.fn(),
+      onPairingRedeemed: jest.fn(),
     };
     publisher = {
       handleViewerSignal: jest.fn(),


### PR DESCRIPTION
Closes #34

PR-G4. Gateway requests pairing codes for unpaired cameras on boot, listens for redemption pushes from the server, persists `dashboardId` bindings back to `gateway.yaml`. Operator can curl `localhost:9090/pairing` to see active codes + paired dashboards.

## Delivered
- Extended `ISignalingClient` with `requestPairingCode` + `onPairingRedeemed`
- `RequestPairingUseCase` (3-retry loop, logs)
- `HandlePairingRedeemedUseCase` (idempotent, validates, persists)
- `PairingStatusHandler` (pure `node:http`, no Express dep)
- 18 new tests (80 total), coverage 90-100%

## Out of scope
- PR-G5 #35: docker-compose + smoke test + README runbook