### PR TITLE
chore(gateway): docker compose, README and main.ts wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,30 @@ docker compose build server && docker compose up -d server
 docker compose logs server | head -n 5
 ```
 
+## Run a real home setup with Tapo cams
+
+For the production data flow (IP cams in your LAN, viewer accessible from
+anywhere on the internet), use `apps/gateway` instead of the browser-based
+`apps/camera`.
+
+```
+[Tapo C200]──RTSP──►[go2rtc]──►[gateway]──signaling──►[server]──►[viewer anywhere]
+        (LAN — Mac/Pi running docker compose)             (Render)    (Vercel)
+```
+
+1. Confirm your Tapo speaks RTSP standalone — see
+   [`apps/gateway/README.md`](apps/gateway/README.md) "Quickstart" step 1.
+2. `cp apps/gateway/gateway.yaml.example gateway/gateway.yaml` and add
+   each camera's RTSP URL.
+3. `docker compose --profile gateway up` — boots both `go2rtc` and the
+   gateway service.
+4. Watch logs for a 6-character pairing code per camera, enter it in the
+   viewer (web or native) once. The binding persists.
+5. `curl http://127.0.0.1:9090/pairing` shows live pairing status.
+
+Full docs (config, troubleshooting, architecture):
+[`apps/gateway/README.md`](apps/gateway/README.md).
+
 ## Branching policy
 
 - `main` — locked. Receives only the v1.0.0 release merge.

--- a/apps/gateway/.dockerignore
+++ b/apps/gateway/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+coverage
+*.log
+.DS_Store
+gateway.yaml
+.env
+.env.*
+!.env.example
+tests

--- a/apps/gateway/Dockerfile
+++ b/apps/gateway/Dockerfile
@@ -1,0 +1,68 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage build for the Sentinel Monitor LAN gateway.
+# Stage 1: install full workspace deps, compile TypeScript.
+# Stage 2: prune to production deps only.
+# Stage 3: minimal runtime image.
+
+ARG NODE_VERSION=20.18.0
+ARG PNPM_VERSION=9.12.0
+
+# ---------- Stage 1: build ----------
+FROM node:${NODE_VERSION}-alpine AS build
+ARG PNPM_VERSION
+WORKDIR /repo
+
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json turbo.json tsconfig.base.json .npmrc ./
+COPY apps/gateway/package.json apps/gateway/
+COPY packages/shared-types/package.json packages/shared-types/
+COPY packages/webrtc-config/package.json packages/webrtc-config/
+
+RUN pnpm install --frozen-lockfile --filter @sentinel-monitor/gateway...
+
+COPY packages/shared-types packages/shared-types
+COPY packages/webrtc-config packages/webrtc-config
+COPY apps/gateway apps/gateway
+
+RUN pnpm --filter @sentinel-monitor/gateway build
+
+# ---------- Stage 2: prune ----------
+FROM node:${NODE_VERSION}-alpine AS prune
+ARG PNPM_VERSION
+WORKDIR /repo
+
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json .npmrc ./
+COPY apps/gateway/package.json apps/gateway/
+COPY packages/shared-types/package.json packages/shared-types/
+COPY packages/webrtc-config/package.json packages/webrtc-config/
+COPY packages/shared-types packages/shared-types
+COPY packages/webrtc-config packages/webrtc-config
+
+RUN pnpm install --frozen-lockfile --prod --filter @sentinel-monitor/gateway...
+
+# ---------- Stage 3: runtime ----------
+FROM node:${NODE_VERSION}-alpine AS runtime
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    LOG_LEVEL=info \
+    GATEWAY_CONFIG_PATH=/app/config/gateway.yaml \
+    GATEWAY_HTTP_PORT=9090
+
+COPY --from=prune /repo/node_modules /app/node_modules
+COPY --from=prune /repo/apps/gateway/node_modules /app/node_modules
+COPY --from=prune /repo/packages /app/packages
+COPY --from=build /repo/apps/gateway/dist /app/dist
+COPY --from=build /repo/apps/gateway/package.json /app/package.json
+
+USER node
+
+EXPOSE 9090
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD wget --quiet --spider http://127.0.0.1:${GATEWAY_HTTP_PORT}/health || exit 1
+
+CMD ["node", "dist/main.js"]

--- a/apps/gateway/README.md
+++ b/apps/gateway/README.md
@@ -1,0 +1,162 @@
+# `@sentinel-monitor/gateway`
+
+LAN-side bridge that publishes home IP cameras (Tapo C200, Reolink, anything
+that speaks RTSP/ONVIF) to the Sentinel Monitor signaling server so a viewer
+anywhere on the internet can subscribe via WebRTC.
+
+```
+[IP cam]──RTSP──►[go2rtc]──WHEP──►[gateway]──signaling──►[server]──WebRTC──►[viewer]
+                                                          (Render)            (anywhere)
+```
+
+The gateway never instantiates an `RTCPeerConnection` itself — it proxies
+WHEP offers from viewers into the local go2rtc bridge. That keeps it
+portable to ARM (Raspberry Pi) without native compilation.
+
+## Quickstart
+
+### 1. Confirm the camera works standalone
+
+Before touching gateway code, verify go2rtc + your Tapo speak to each other:
+
+```bash
+docker run --rm --network host \
+  -e GO2RTC_CONFIG='streams:
+    sala: rtsp://USER:PASS@TAPO_IP:554/stream1' \
+  alexxit/go2rtc
+```
+
+Open `http://localhost:1984`, click `sala`, see live video. If this fails,
+the issue is the Tapo (Camera Account not configured in the Tapo app, wrong
+RTSP path — try `/stream2`, wrong creds). Fix this before anything else.
+
+### 2. Configure the gateway
+
+Copy the example config and edit it:
+
+```bash
+mkdir -p gateway
+cp apps/gateway/gateway.yaml.example gateway/gateway.yaml
+$EDITOR gateway/gateway.yaml
+```
+
+Minimal config:
+
+```yaml
+gateway:
+  signalingUrl: "https://sentinel-server.onrender.com"
+  go2rtcUrl: "http://127.0.0.1:1984"
+  cameras:
+    - label: "Sala"
+      rtspUrl: "rtsp://USER:PASS@192.168.0.42:554/stream2"
+```
+
+UUIDs are filled in on first boot and written back to the file — identity
+stays stable across restarts.
+
+Create a matching go2rtc config (the gateway will register streams via
+go2rtc's REST API but go2rtc still needs its own bind config):
+
+```yaml
+# gateway/go2rtc.yaml
+api:
+  listen: ":1984"
+webrtc:
+  listen: ":8555"
+```
+
+### 3. Run with Docker Compose
+
+```bash
+docker compose --profile gateway up
+```
+
+This starts both `go2rtc` and `gateway`. Watch the logs for the pairing code:
+
+```
+INFO  pairing.code_issued  cameraLabel=Sala  code=ABC123
+```
+
+Open the viewer (web or native), tap **Add camera**, enter the code. Once
+paired, the binding is persisted to `gateway.yaml` — restarts reconnect
+automatically without prompting again.
+
+### 4. Inspect status
+
+A tiny HTTP server runs on `127.0.0.1:9090`:
+
+```bash
+curl -s http://127.0.0.1:9090/pairing | jq
+curl -s http://127.0.0.1:9090/health
+```
+
+`/pairing` shows each camera, who it's paired with, and any active code.
+
+## Run locally without Docker
+
+```bash
+pnpm install
+pnpm --filter @sentinel-monitor/gateway dev
+```
+
+Set `GATEWAY_CONFIG_PATH` to point at your YAML if it's not in CWD:
+
+```bash
+GATEWAY_CONFIG_PATH=./gateway/gateway.yaml \
+  pnpm --filter @sentinel-monitor/gateway dev
+```
+
+You still need go2rtc running somewhere reachable (its URL goes in
+`gateway.go2rtcUrl`).
+
+## Environment variables
+
+| Variable | Default | Notes |
+|---|---|---|
+| `GATEWAY_CONFIG_PATH` | `./gateway.yaml` | Absolute or relative path to the YAML config. |
+| `GATEWAY_HTTP_PORT` | `9090` | Port for the local pairing inspector (binds to 127.0.0.1 only). |
+| `LOG_LEVEL` | `info` | One of `fatal`, `error`, `warn`, `info`, `debug`, `trace`. |
+| `NODE_ENV` | `development` | `production` disables pretty logs. |
+
+## Architecture (Clean Architecture)
+
+```
+src/
+├── domain/
+│   ├── entities/                 # CameraConfig, GatewayConfig
+│   ├── repositories/             # IConfigStorage, IGo2RtcClient, ISignaling, ICameraPublisher
+│   └── use-cases/                # StartCamera, StopCamera, RequestPairing, HandlePairingRedeemed
+├── infrastructure/
+│   ├── config/                   # YAML+Zod storage with UUID backfill
+│   ├── go2rtc/                   # REST adapter for go2rtc
+│   ├── logging/                  # ILogger + Pino adapter
+│   ├── signaling/                # Socket.IO client implementing ISignalingClient
+│   └── webrtc/                   # GatewayCameraPublisher (WHEP proxy)
+├── presentation/
+│   └── http/                     # Pairing-status HTTP inspector
+└── main.ts                       # Composition root
+```
+
+Dependencies always point inward: domain has zero framework imports.
+
+## Troubleshooting
+
+**`go2rtc.unreachable` — gateway exits at startup**
+The gateway retries 10× over 20 s waiting for go2rtc. If go2rtc never
+responds at the URL in `gateway.go2rtcUrl`, the process exits. With
+`network_mode: host` (compose default), the URL should be
+`http://127.0.0.1:1984`.
+
+**Pairing code never appears in logs**
+The signaling server may be unreachable. Check `signaling.connected` events
+in the logs. If you see `connect_error`, validate `signalingUrl` and that
+the server is running.
+
+**Viewer pairs but sees no video**
+1. Confirm the camera publishes in go2rtc UI (`http://127.0.0.1:1984`).
+2. Check viewer devtools for ICE failures — restrictive NATs need TURN.
+3. Confirm `pairedDashboards` in `gateway.yaml` was written back.
+
+**`registerStream failed: HTTP 400`**
+go2rtc rejected the RTSP URL. Test it with VLC first
+(`File → Open Network → rtsp://...`).

--- a/apps/gateway/src/main.ts
+++ b/apps/gateway/src/main.ts
@@ -1,12 +1,28 @@
 // Composition root for the Sentinel Monitor LAN gateway.
-// PR-G1: scaffold only — loads YAML config and prints the parsed
-// gateway + cameras. Subsequent PRs add go2rtc + signaling + WebRTC.
+// Wires config → go2rtc → signaling → publishers → pairing → HTTP inspector.
 
 import { resolve } from 'node:path';
 import { YamlConfigStorageRepository } from './infrastructure/config/yaml-config-storage.repository';
-import { createLogger } from './infrastructure/logging/logger';
+import { createLogger, type ILogger } from './infrastructure/logging/logger';
+import { Go2RtcClient } from './infrastructure/go2rtc/go2rtc.client';
+import { SocketIoSignalingClient } from './infrastructure/signaling/socketio-signaling.client';
+import { GatewayCameraPublisher } from './infrastructure/webrtc/gateway-camera-publisher';
+import { StartCameraUseCase } from './domain/use-cases/start-camera.use-case';
+import { StopCameraUseCase } from './domain/use-cases/stop-camera.use-case';
+import { RequestPairingUseCase } from './domain/use-cases/request-pairing.use-case';
+import { HandlePairingRedeemedUseCase } from './domain/use-cases/handle-pairing-redeemed.use-case';
+import { PairingStatusHandler } from './presentation/http/pairing-status.handler';
+import type { CameraConfig } from './domain/entities/camera-config.entity';
+import type { GatewayConfig } from './domain/entities/gateway-config.entity';
 
 const CONFIG_PATH = process.env.GATEWAY_CONFIG_PATH ?? resolve(process.cwd(), 'gateway.yaml');
+const PAIRING_HTTP_PORT = Number(process.env.GATEWAY_HTTP_PORT ?? 9090);
+const GO2RTC_HEALTH_RETRIES = 10;
+const GO2RTC_HEALTH_DELAY_MS = 2_000;
+
+interface CameraRuntime {
+  readonly stop: () => Promise<void>;
+}
 
 async function main(): Promise<void> {
   const logger = createLogger({
@@ -14,19 +30,10 @@ async function main(): Promise<void> {
     pretty: process.env.NODE_ENV !== 'production',
   });
 
-  logger.info({ event: 'boot.starting', configPath: CONFIG_PATH });
+  logger.info({ event: 'boot.starting', configPath: CONFIG_PATH }, 'Gateway starting');
 
   const configRepo = new YamlConfigStorageRepository(CONFIG_PATH);
-  let config;
-  try {
-    config = await configRepo.load();
-  } catch (err) {
-    logger.error(
-      { event: 'boot.config_failed', error: err instanceof Error ? err.message : String(err) },
-      'Failed to load gateway configuration',
-    );
-    process.exit(1);
-  }
+  const config = await loadConfigOrExit(configRepo, logger);
 
   logger.info(
     {
@@ -39,17 +46,158 @@ async function main(): Promise<void> {
     'Gateway configuration loaded',
   );
 
-  for (const cam of config.cameras) {
-    logger.info(
-      { event: 'boot.camera', id: cam.id, label: cam.label, paired: cam.pairedDashboards.length },
-      `Camera registered: ${cam.label}`,
-    );
+  const go2rtc = new Go2RtcClient({ baseUrl: config.go2rtcUrl });
+  await waitForGo2Rtc(go2rtc, logger);
+
+  const httpInspector = new PairingStatusHandler({ logger, port: PAIRING_HTTP_PORT });
+  httpInspector.setConfig(config);
+  await httpInspector.start();
+
+  const runtimes = new Map<string, CameraRuntime>();
+
+  for (const camera of config.cameras) {
+    try {
+      const runtime = await startCamera({
+        camera,
+        config,
+        configRepo,
+        go2rtc,
+        httpInspector,
+        logger,
+      });
+      runtimes.set(camera.id, runtime);
+    } catch (err) {
+      logger.error(
+        {
+          event: 'boot.camera_failed',
+          cameraId: camera.id,
+          cameraLabel: camera.label,
+          error: err instanceof Error ? err.message : String(err),
+        },
+        `Failed to start camera "${camera.label}"`,
+      );
+    }
   }
 
-  logger.warn(
-    { event: 'boot.scaffold_only' },
-    'PR-G1 scaffold: no go2rtc, no signaling, no WebRTC yet. Subsequent PRs will wire these.',
+  logger.info(
+    { event: 'boot.ready', online: runtimes.size, total: config.cameras.length },
+    `Gateway ready (${runtimes.size}/${config.cameras.length} cameras online)`,
   );
+
+  const shutdown = async (signal: string): Promise<void> => {
+    logger.info({ event: 'boot.shutdown', signal }, `Shutting down (${signal})`);
+    await Promise.all(
+      Array.from(runtimes.values()).map((r) => r.stop().catch(() => undefined)),
+    );
+    await httpInspector.stop();
+    process.exit(0);
+  };
+
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
+  process.on('SIGINT', () => void shutdown('SIGINT'));
+}
+
+async function loadConfigOrExit(
+  configRepo: YamlConfigStorageRepository,
+  logger: ILogger,
+): Promise<GatewayConfig> {
+  try {
+    return await configRepo.load();
+  } catch (err) {
+    logger.error(
+      { event: 'boot.config_failed', error: err instanceof Error ? err.message : String(err) },
+      'Failed to load gateway configuration',
+    );
+    process.exit(1);
+  }
+}
+
+async function waitForGo2Rtc(go2rtc: Go2RtcClient, logger: ILogger): Promise<void> {
+  for (let attempt = 1; attempt <= GO2RTC_HEALTH_RETRIES; attempt++) {
+    try {
+      const result = await go2rtc.health();
+      logger.info(
+        { event: 'go2rtc.health_ok', attempt, version: result.version },
+        'go2rtc reachable',
+      );
+      return;
+    } catch (err) {
+      logger.warn(
+        {
+          event: 'go2rtc.health_retry',
+          attempt,
+          maxAttempts: GO2RTC_HEALTH_RETRIES,
+          error: err instanceof Error ? err.message : String(err),
+        },
+        'Waiting for go2rtc',
+      );
+      await new Promise((r) => setTimeout(r, GO2RTC_HEALTH_DELAY_MS));
+    }
+  }
+  logger.error({ event: 'go2rtc.unreachable' }, 'go2rtc never came online; exiting');
+  process.exit(1);
+}
+
+interface StartCameraArgs {
+  readonly camera: CameraConfig;
+  readonly config: GatewayConfig;
+  readonly configRepo: YamlConfigStorageRepository;
+  readonly go2rtc: Go2RtcClient;
+  readonly httpInspector: PairingStatusHandler;
+  readonly logger: ILogger;
+}
+
+async function startCamera(args: StartCameraArgs): Promise<CameraRuntime> {
+  const { camera, config, configRepo, go2rtc, httpInspector, logger } = args;
+  const childLogger = logger.child({ cameraId: camera.id, cameraLabel: camera.label });
+
+  const signaling = new SocketIoSignalingClient({ logger: childLogger });
+  const publisher = new GatewayCameraPublisher({
+    cameraId: camera.id,
+    streamId: camera.id,
+    whepBaseUrl: go2rtc.getWhepUrl(camera.id),
+    logger: childLogger,
+  });
+
+  const startUseCase = new StartCameraUseCase({ signaling, publisher, go2rtc });
+  const stopUseCase = new StopCameraUseCase({ signaling, publisher, go2rtc });
+  const requestPairing = new RequestPairingUseCase({ signaling, logger: childLogger });
+  const handleRedeemed = new HandlePairingRedeemedUseCase({
+    configStorage: configRepo,
+    logger: childLogger,
+  });
+
+  const result = await startUseCase.execute({
+    camera,
+    signalingUrl: config.signalingUrl,
+  });
+  if (!result.started) {
+    throw new Error(result.reason);
+  }
+
+  signaling.onPairingRedeemed((event) => {
+    void handleRedeemed.execute(event).then(async (handled) => {
+      if (handled.handled) {
+        const refreshed = await configRepo.load();
+        httpInspector.setConfig(refreshed);
+        httpInspector.clearPrompt(camera.id);
+      }
+    });
+  });
+
+  if (camera.pairedDashboards.length === 0) {
+    try {
+      const prompt = await requestPairing.execute(camera);
+      httpInspector.setPrompt(prompt);
+    } catch {
+      // RequestPairingUseCase already logged the exhaustion. Keep the camera
+      // running; operator can restart later or pair via the inspector retry.
+    }
+  }
+
+  return {
+    stop: () => stopUseCase.execute({ cameraId: camera.id }),
+  };
 }
 
 void main().catch((err: unknown) => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,3 +26,52 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
+
+  # ---------------------------------------------------------------------------
+  # LAN gateway stack — opt in via `--profile gateway`.
+  #   docker compose --profile gateway up
+  #
+  # go2rtc bridges RTSP from your IP cams (Tapo C200, Reolink, etc.) to WebRTC.
+  # The gateway service registers each camera with go2rtc, connects to the
+  # signaling server using a stable per-camera UUID, and proxies WHEP offers
+  # back to viewers anywhere on the internet.
+  # ---------------------------------------------------------------------------
+  go2rtc:
+    container_name: sentinel-go2rtc
+    image: alexxit/go2rtc:latest
+    profiles: ["gateway"]
+    restart: unless-stopped
+    network_mode: host
+    volumes:
+      - ./gateway/go2rtc.yaml:/config/go2rtc.yaml:ro
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--spider", "http://127.0.0.1:1984/api/streams"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  gateway:
+    container_name: sentinel-gateway
+    build:
+      context: .
+      dockerfile: apps/gateway/Dockerfile
+    image: sentinel-monitor/gateway:local
+    profiles: ["gateway"]
+    restart: unless-stopped
+    network_mode: host
+    depends_on:
+      - go2rtc
+    environment:
+      NODE_ENV: production
+      LOG_LEVEL: ${GATEWAY_LOG_LEVEL:-info}
+      GATEWAY_CONFIG_PATH: /app/config/gateway.yaml
+      GATEWAY_HTTP_PORT: 9090
+    volumes:
+      - ./gateway/gateway.yaml:/app/config/gateway.yaml
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--spider", "http://127.0.0.1:9090/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s


### PR DESCRIPTION
## Summary

- Wires `apps/gateway/src/main.ts` composition root: per-camera StartCamera + RequestPairing + HandlePairingRedeemed, with PairingStatusHandler on 127.0.0.1:9090.
- Adds `apps/gateway/Dockerfile` (multi-stage Node 20 alpine, pnpm prune, non-root) and `.dockerignore`.
- Extends root `docker-compose.yml` with a `gateway` profile bundling `gateway` + `go2rtc` (alexxit/go2rtc) under host networking — opt in via `docker compose --profile gateway up`.
- Adds `apps/gateway/README.md` (quickstart, env vars, troubleshooting) and a "Run a real home setup with Tapo cams" section in the root README.

Closes #35

## Test plan

- [x] `pnpm --filter @sentinel-monitor/gateway typecheck` green
- [x] `pnpm --filter @sentinel-monitor/gateway test` — 80/80 pass
- [x] `pnpm --filter @sentinel-monitor/gateway build` green
- [ ] `docker compose --profile gateway build` succeeds in CI
- [ ] Manual smoke: gateway boots against a real Tapo, pairing code appears in logs, `curl http://127.0.0.1:9090/pairing` returns the snapshot