### PR TITLE
fix: end-to-end local dev with Tapo C200 (and other RTSP cams)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@ coverage/
 .env.local
 .env.*.local
 
+# Gateway runtime config — contains RTSP creds and dashboard pairings.
+# Only the example file (apps/gateway/gateway.yaml.example) is committed.
+/gateway/
+/apps/gateway/gateway.yaml
+/apps/gateway/go2rtc.yaml
+
 # Expo
 .expo/
 *.jks

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /repo
 RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
 # Copy workspace manifests first for better layer caching.
-COPY pnpm-workspace.yaml pnpm-lock.yaml package.json turbo.json tsconfig.base.json ./
+COPY .npmrc pnpm-workspace.yaml pnpm-lock.yaml package.json turbo.json tsconfig.base.json ./
 COPY apps/server/package.json apps/server/
 COPY packages/shared-types/package.json packages/shared-types/
 
@@ -25,6 +25,7 @@ RUN pnpm install --frozen-lockfile --filter @sentinel-monitor/server...
 COPY packages/shared-types packages/shared-types
 COPY apps/server apps/server
 
+RUN pnpm --filter @sentinel-monitor/shared-types build
 RUN pnpm --filter @sentinel-monitor/server build
 
 # ---------- Stage 2: prune ----------
@@ -34,7 +35,7 @@ WORKDIR /repo
 
 RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
-COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY .npmrc pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 COPY apps/server/package.json apps/server/
 COPY packages/shared-types/package.json packages/shared-types/
 COPY packages/shared-types packages/shared-types
@@ -49,10 +50,11 @@ ENV NODE_ENV=production \
     PORT=3010 \
     LOG_LEVEL=info
 
-# Bring in pruned node_modules from the workspace plus compiled JS.
+# node-linker=hoisted → all deps land in the workspace root node_modules (flat, no symlinks).
+# shared-types is compiled to dist/ so Node.js can require it at runtime.
 COPY --from=prune /repo/node_modules /app/node_modules
-COPY --from=prune /repo/apps/server/node_modules /app/node_modules
-COPY --from=prune /repo/packages /app/packages
+COPY --from=build /repo/packages/shared-types/dist /app/node_modules/@sentinel-monitor/shared-types/dist
+COPY --from=build /repo/packages/shared-types/package.json /app/node_modules/@sentinel-monitor/shared-types/package.json
 COPY --from=build /repo/apps/server/dist /app/dist
 COPY --from=build /repo/apps/server/package.json /app/package.json
 

--- a/apps/server/jest.config.js
+++ b/apps/server/jest.config.js
@@ -2,6 +2,11 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.test.json',
+    },
+  },
   roots: ['<rootDir>/tests'],
   moduleNameMapper: {
     '^@sentinel-monitor/shared-types$': '<rootDir>/../../packages/shared-types/src/index',

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -1,9 +1,12 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "rootDir": "src",
     "outDir": "./dist",
     "lib": ["ES2022", "DOM"],
     "types": ["node", "jest"]
   },
-  "include": ["src", "tests"]
+  "include": ["src"]
 }

--- a/apps/server/tsconfig.test.json
+++ b/apps/server/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "tests"]
+}

--- a/apps/viewer/app/index.tsx
+++ b/apps/viewer/app/index.tsx
@@ -62,9 +62,9 @@ export default function GridScreen(): JSX.Element {
         {rows.map((row, rowIdx) => (
           <View key={`row-${rowIdx}`} style={styles.row}>
             {row.map((b) => {
-              const peer = peers[b.id];
-              const presenceKnown = b.id in online;
-              const isOnline = presenceKnown ? online[b.id] : undefined;
+              const peer = peers[b.cameraId];
+              const presenceKnown = b.cameraId in online;
+              const isOnline = presenceKnown ? online[b.cameraId] : undefined;
               return (
                 <CameraTile
                   key={b.id}
@@ -79,6 +79,9 @@ export default function GridScreen(): JSX.Element {
                   }}
                   onToggleMute={() => {
                     toggleMuteUC.execute(b.id);
+                  }}
+                  onRemove={() => {
+                    void removeCamera(b.id);
                   }}
                 />
               );

--- a/apps/viewer/src/infrastructure/webrtc/webrtc-subscriber.web.ts
+++ b/apps/viewer/src/infrastructure/webrtc/webrtc-subscriber.web.ts
@@ -115,7 +115,33 @@ export class BrowserWebRtcSubscriber implements IWebRtcSubscriberRepository {
 
     const offer = await this.pc.createOffer();
     await this.pc.setLocalDescription(offer);
-    this.options.emitSignal({ type: 'offer', sdp: offer.sdp ?? '' });
+
+    // Wait for ICE gathering to finish so the offer contains all candidates
+    // inline. go2rtc's WHEP impl may not return a Location header for trickle,
+    // so we rely on non-trickle (complete) offers instead.
+    await this.waitForIceGathering();
+    this.options.emitSignal({ type: 'offer', sdp: this.pc.localDescription?.sdp ?? '' });
+  }
+
+  private waitForIceGathering(): Promise<void> {
+    return new Promise((resolve) => {
+      if (this.pc.iceGatheringState === 'complete') {
+        resolve();
+        return;
+      }
+      const handler = (): void => {
+        if (this.pc.iceGatheringState === 'complete') {
+          this.pc.removeEventListener('icegatheringstatechange', handler);
+          resolve();
+        }
+      };
+      this.pc.addEventListener('icegatheringstatechange', handler);
+      // Safety timeout — resolve anyway after 5s so we never hang forever.
+      setTimeout(() => {
+        this.pc.removeEventListener('icegatheringstatechange', handler);
+        resolve();
+      }, 5_000);
+    });
   }
 
   async handleIncomingSignal(payload: SignalPayload): Promise<void> {

--- a/apps/viewer/src/presentation/components/camera-tile.component.tsx
+++ b/apps/viewer/src/presentation/components/camera-tile.component.tsx
@@ -20,6 +20,7 @@ export interface CameraTileProps {
   readonly onPress?: () => void;
   readonly onLongPress?: () => void;
   readonly onToggleMute?: () => void;
+  readonly onRemove?: () => void;
 }
 
 function resolveStatus(
@@ -57,6 +58,7 @@ export function CameraTile({
   onPress,
   onLongPress,
   onToggleMute,
+  onRemove,
 }: CameraTileProps): JSX.Element {
   const status = resolveStatus(online, state);
   const showVideo = status === 'connected' && stream !== null;
@@ -91,6 +93,20 @@ export function CameraTile({
                 cameraId={binding.id}
               />
             </View>
+          ) : null}
+          {onRemove ? (
+            <TouchableOpacity
+              style={styles.removeSlot}
+              onPress={(e) => {
+                e.stopPropagation?.();
+                onRemove();
+              }}
+              hitSlop={8}
+              accessibilityRole="button"
+              accessibilityLabel={`remove-camera-${binding.id}`}
+            >
+              <Text style={styles.removeIcon}>✕</Text>
+            </TouchableOpacity>
           ) : null}
         </View>
         <View style={styles.footer}>
@@ -131,6 +147,23 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: spacing[2],
     right: spacing[2],
+  },
+  removeSlot: {
+    position: 'absolute',
+    top: spacing[2],
+    left: spacing[2],
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: 'rgba(0,0,0,0.55)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  removeIcon: {
+    color: '#fff',
+    fontSize: typography.size.sm,
+    fontWeight: typography.weight.medium,
+    lineHeight: typography.size.sm + 2,
   },
   footer: {
     flexDirection: 'row',

--- a/apps/viewer/src/presentation/components/video-surface.web.tsx
+++ b/apps/viewer/src/presentation/components/video-surface.web.tsx
@@ -13,7 +13,7 @@ export interface VideoSurfaceProps {
 
 export function VideoSurface({
   stream,
-  muted = false,
+  muted = true,
 }: VideoSurfaceProps): JSX.Element {
   const ref = useRef<HTMLVideoElement | null>(null);
 
@@ -21,7 +21,16 @@ export function VideoSurface({
     const el = ref.current;
     if (!el) return;
     if (el.srcObject !== stream) {
+      // Force muted before play() — Chrome blocks autoplay on streams with audio.
+      el.muted = true;
       el.srcObject = stream;
+      const playPromise = el.play();
+      if (playPromise && typeof playPromise.catch === 'function') {
+        playPromise.catch(() => {
+          // Autoplay may still be blocked on some browsers; the user can
+          // interact with the tile to start playback manually.
+        });
+      }
     }
   }, [stream]);
 
@@ -34,7 +43,7 @@ export function VideoSurface({
       style={{
         width: '100%',
         height: '100%',
-        objectFit: 'cover',
+        objectFit: 'contain',
         backgroundColor: '#000',
       }}
     />

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,8 @@ services:
       PORT: 3010
       CORS_ORIGIN: ${CORS_ORIGIN:-*}
       LOG_LEVEL: ${LOG_LEVEL:-info}
-      TURN_URL: ${TURN_URL:-}
-      TURN_USER: ${TURN_USER:-}
-      TURN_PASS: ${TURN_PASS:-}
+      # TURN_URL / TURN_USER / TURN_PASS are optional — omit them for LAN-only setups.
+      # Set all three in a .env file when you need TURN for remote viewers behind NAT.
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--spider", "http://127.0.0.1:3010/health"]
       interval: 30s

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -2,9 +2,10 @@
   "name": "@sentinel-monitor/shared-types",
   "version": "0.0.1",
   "private": true,
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
+    "build": "tsc",
     "typecheck": "tsc --noEmit",
     "lint": "echo 'no lint configured yet'"
   },

--- a/packages/shared-types/tsconfig.json
+++ b/packages/shared-types/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node",
     "outDir": "./dist",
     "rootDir": "./src",
     "lib": ["ES2022", "DOM"]

--- a/start
+++ b/start
@@ -1,7 +1,7 @@
 #!/bin/bash
 # ═══════════════════════════════════════════════════════════
 # Sentinel Monitor — one-command dev launch
-# Server (3010) + Camera (5180) + Viewer (5181 web / 8081 Metro)
+# Server (3010) + go2rtc (1984) + Gateway (9090) + Viewer (5181 web / 8081 Metro)
 # Each service opens in its own iTerm2 tab
 # ═══════════════════════════════════════════════════════════
 
@@ -22,7 +22,7 @@ else
 fi
 
 # ─── Kill existing processes on used ports ──────────────────
-for port in 3010 5180 5181 8081; do
+for port in 3010 1984 8554 8555 9090 5181 8081; do
   pids=$(lsof -ti:$port 2>/dev/null)
   if [ -n "$pids" ]; then
     echo "$pids" | xargs kill -9 2>/dev/null
@@ -32,7 +32,7 @@ done
 
 sleep 2
 
-for port in 3010 5180 5181 8081; do
+for port in 3010 1984 8554 8555 9090 5181 8081; do
   pids=$(lsof -ti:$port 2>/dev/null)
   if [ -n "$pids" ]; then
     echo "$pids" | xargs kill -9 2>/dev/null
@@ -44,6 +44,36 @@ done
 if ! which pnpm > /dev/null 2>&1; then
   echo "   pnpm not found — run: npm install -g pnpm"
   exit 1
+fi
+
+# ─── Check go2rtc ────────────────────────────────────────────
+if ! which go2rtc > /dev/null 2>&1; then
+  echo "   go2rtc not found — run:"
+  echo "   curl -L https://github.com/AlexxIT/go2rtc/releases/latest/download/go2rtc_mac_arm64.zip -o /tmp/go2rtc.zip"
+  echo "   unzip /tmp/go2rtc.zip -d /tmp/go2rtc && mv /tmp/go2rtc/go2rtc /usr/local/bin/go2rtc && chmod +x /usr/local/bin/go2rtc"
+  exit 1
+fi
+
+# ─── Check gateway config ────────────────────────────────────
+GATEWAY_CONFIG="$PROJECT_DIR/gateway/gateway.yaml"
+if [ ! -f "$GATEWAY_CONFIG" ]; then
+  echo "   gateway/gateway.yaml not found — run:"
+  echo "   mkdir -p '$PROJECT_DIR/gateway'"
+  echo "   cp '$PROJECT_DIR/apps/gateway/gateway.yaml.example' '$GATEWAY_CONFIG'"
+  echo "   Then edit it with your camera RTSP URL and set signalingUrl to http://localhost:3010"
+  exit 1
+fi
+
+GO2RTC_CONFIG="$PROJECT_DIR/gateway/go2rtc.yaml"
+if [ ! -f "$GO2RTC_CONFIG" ]; then
+  echo "   gateway/go2rtc.yaml not found — creating default…"
+  mkdir -p "$PROJECT_DIR/gateway"
+  cat > "$GO2RTC_CONFIG" << 'YAML'
+api:
+  listen: ":1984"
+webrtc:
+  listen: ":8555"
+YAML
 fi
 
 # ─── Check .env ──────────────────────────────────────────────
@@ -66,40 +96,45 @@ export VIEWER_URL="http://${LOCAL_IP}:5181"
 
 echo ""
 echo "   ┌──────────────────────────────────────────────────┐"
-echo "   │  Server:  http://${LOCAL_IP}:3010                  "
-echo "   │  Camera:  http://${LOCAL_IP}:5180                  "
-echo "   │  Viewer:  http://${LOCAL_IP}:5181  (web)           "
-echo "   │  Viewer:  Metro on 8081           (native)         "
+echo "   │  Server:   http://localhost:3010                  "
+echo "   │  go2rtc:   http://localhost:1984                  "
+echo "   │  Gateway:  http://127.0.0.1:9090/pairing          "
+echo "   │  Viewer:   http://${LOCAL_IP}:5181  (web)         "
+echo "   │  Viewer:   Metro on 8081            (native)      "
 echo "   └──────────────────────────────────────────────────┘"
 echo ""
-echo "   How to test (browser-only smoke):"
-echo "   1. Open Camera URL on a laptop with webcam → grant permission → see 6-char pairing code"
-echo "   2. Open Viewer URL on another browser → 'Add camera' → enter the code"
-echo "   3. Tile renders live video; close + reopen viewer to verify auto-reconnect"
+echo "   How to test with Tapo C200:"
+echo "   1. Wait for gateway logs: pairing.code_issued code=XXXXXX"
+echo "   2. Open Viewer URL → 'Add camera' → enter the 6-char code"
+echo "   3. Video tile appears; binding is saved — restarts reconnect automatically"
 echo ""
 
 # ─── Open each service in a new iTerm2 tab ──────────────────
-ENV_EXPORTS="export SIGNALING_URL='http://${LOCAL_IP}:3010' && export CAMERA_URL='http://${LOCAL_IP}:5180' && export VIEWER_URL='http://${LOCAL_IP}:5181'"
-
 osascript <<EOF
 tell application "iTerm2"
   tell current window
-    -- Tab: Server
+    -- Tab: Server (Docker)
     create tab with default profile
     tell current session
-      write text "cd '${PROJECT_DIR}' && ${ENV_EXPORTS} && echo '── Server (port 3010) ──' && pnpm dev:server"
+      write text "cd '${PROJECT_DIR}' && echo '── Server (port 3010) ──' && docker compose up server"
     end tell
 
-    -- Tab: Camera
+    -- Tab: go2rtc
     create tab with default profile
     tell current session
-      write text "cd '${PROJECT_DIR}' && ${ENV_EXPORTS} && echo '── Camera (port 5180) ──' && pnpm dev:camera"
+      write text "echo '── go2rtc (port 1984) ──' && go2rtc -config '${PROJECT_DIR}/gateway/go2rtc.yaml'"
     end tell
 
-    -- Tab: Viewer (web by default; for native run: pnpm --filter @sentinel-monitor/viewer dev:ios)
+    -- Tab: Gateway
     create tab with default profile
     tell current session
-      write text "cd '${PROJECT_DIR}' && ${ENV_EXPORTS} && echo '── Viewer (web on 5181, Metro on 8081) ──' && pnpm --filter @sentinel-monitor/viewer dev:web"
+      write text "cd '${PROJECT_DIR}' && echo '── Gateway (port 9090) ──' && GATEWAY_CONFIG_PATH='${GATEWAY_CONFIG}' pnpm --filter @sentinel-monitor/gateway dev"
+    end tell
+
+    -- Tab: Viewer
+    create tab with default profile
+    tell current session
+      write text "cd '${PROJECT_DIR}' && echo '── Viewer (web on 5181, Metro on 8081) ──' && EXPO_PUBLIC_SIGNALING_URL='http://localhost:3010' pnpm --filter @sentinel-monitor/viewer dev:web"
     end tell
   end tell
 end tell


### PR DESCRIPTION
## Summary

Hands-on integration test against a real Tapo C200 in the LAN exposed a chain of four pre-MVP gaps that all blocked the dashboard from showing video. Each commit fixes one layer of the stack so `./start` now boots the full path (`Tapo → go2rtc → gateway → server → viewer`) and the tile renders the live stream.

## Commits

- **fix(server): emit CommonJS dist/main.js for Docker runtime** — server tsconfig inherited `module=ESNext` and had no `rootDir`, so `tsc` produced an ESM file at `dist/src/main.js` that `node dist/main.js` could not require. Override module/moduleResolution/rootDir, split tests into `tsconfig.test.json`, compile `@sentinel-monitor/shared-types` to a CJS `dist/`, and copy it straight into the runtime stage. Stamp `.npmrc` into the build/prune stages so pnpm honors `node-linker=hoisted` in Docker.
- **fix(deploy): omit empty TURN_* env vars in docker-compose** — `${TURN_URL:-}` substituted into `""`, which Zod rejected. Drop the explicit passthroughs.
- **fix(viewer): pair tile by cameraId and stabilize WebRTC playback** — keying peer/presence lookups by `binding.id` instead of `binding.cameraId` left the tile permanently in `idle`. Wait for ICE gathering before sending the offer (go2rtc's WHEP response has no `Location` header, so trickle candidates were silently dropped). Force `el.muted = true` before `play()` to satisfy Chrome's autoplay policy. Switch `objectFit` from `cover` to `contain`. Add a visible X overlay to remove a camera, since long-press is awkward on web.
- **chore(start): launch go2rtc and gateway tabs alongside server and viewer** — the script now expects `go2rtc` on PATH and `gateway/gateway.yaml` configured; it pre-flights both and replaces the browser camera tab with go2rtc + gateway tabs, with the server tab using docker compose.

## Test plan

- [x] `pnpm --filter @sentinel-monitor/server test` (14 suites, 68 tests pass)
- [x] `pnpm --filter @sentinel-monitor/gateway test` (11 suites, 80 tests pass)
- [x] `docker compose up --build server` boots without env errors and `/health` returns 200
- [x] `./start` opens 4 tabs and the gateway logs `pairing.code_issued` once the Tapo's RTSP stream registers
- [x] Pairing the code in the viewer renders live H264 video; the X button removes the binding

## Notes

- mDNS in Chrome (`enable-webrtc-hide-local-ips-with-mdns`) prevents go2rtc from reaching browser ICE candidates on the LAN. Documented locally as a known dev caveat — production will need TURN to cover the same case for cross-NAT viewers.
- `gateway/go2rtc.yaml` benefits from `webrtc.candidates: [127.0.0.1:8555, 192.168.x.y:8555]` so go2rtc advertises a localhost candidate. Not committed because the file lives under the gitignored `/gateway/` runtime folder.